### PR TITLE
chore: show not found msg on reaction role list null

### DIFF
--- a/src/commands/config/reactionRole/list.ts
+++ b/src/commands/config/reactionRole/list.ts
@@ -41,8 +41,10 @@ const command: Command = {
             }
           })
         )
-        description = values.length
-          ? values.join("")
+
+        const data = values.join("").trim()
+        description = data.length
+          ? data
           : "No reaction role configurations found"
       } else {
         description = "Failed to get reaction role configurations"


### PR DESCRIPTION
**What does this PR do?**

-  Show msg on `$rr list` data is empty