### PR TITLE
chore: update nft recent

### DIFF
--- a/src/commands/community/nft/recent.ts
+++ b/src/commands/community/nft/recent.ts
@@ -1,18 +1,13 @@
 import { Message } from "discord.js"
 import { Command } from "types/common"
 import { PREFIX } from "utils/constants"
-import {
-  composeEmbedMessage,
-  getErrorEmbed,
-  getPaginationRow,
-  listenForPaginateAction,
-} from "utils/discordEmbed"
+import { composeEmbedMessage, getErrorEmbed } from "utils/discordEmbed"
 import Community from "adapters/community"
 import { renderSupportedNFTList } from "utils/canvas"
 import { emojis, getEmojiURL } from "utils/common"
 
 async function composeNFTListEmbed(msg: Message, pageIdx: number) {
-  const { data, page, size, total } = await Community.getCurrentNFTCollections({
+  const { data } = await Community.getCurrentNFTCollections({
     page: pageIdx,
     size: 16,
   })
@@ -30,17 +25,14 @@ async function composeNFTListEmbed(msg: Message, pageIdx: number) {
     }
   }
 
-  const totalPage = Math.ceil(total / size)
   const embed = composeEmbedMessage(msg, {
     author: ["Newly Supported NFT Collections", getEmojiURL(emojis["SPARKLE"])],
     image: `attachment://nftlist.png`,
-    footer: [`Page ${pageIdx + 1} / ${totalPage}`],
   })
 
   return {
     messageOptions: {
       embeds: [embed],
-      components: getPaginationRow(page, totalPage),
       files: [await renderSupportedNFTList(data)],
     },
   }
@@ -52,14 +44,8 @@ const command: Command = {
   brief: "Show list of newly added NFTs",
   category: "Community",
   run: async function (msg: Message) {
-    const index = 0
-    const msgOpts = await composeNFTListEmbed(msg, index)
-    const reply = await msg.reply(msgOpts.messageOptions)
-
-    listenForPaginateAction(reply, msg, composeNFTListEmbed)
-    return {
-      messageOptions: null,
-    }
+    const msgOpts = await composeNFTListEmbed(msg, 0)
+    return msgOpts
   },
   getHelpMessage: async (msg) => ({
     embeds: [


### PR DESCRIPTION
**What does this PR do?**

- `$nft recent` no longer has paging

**Media (Loom or gif)**

<img width="479" alt="Screen Shot 2022-07-11 at 10 27 04" src="https://user-images.githubusercontent.com/84314071/178183012-75ef9be5-3e37-4a70-9ba8-f1ac951d639b.png">

