### PR TITLE
feat: verify wallet cmds

### DIFF
--- a/src/adapters/community.ts
+++ b/src/adapters/community.ts
@@ -409,6 +409,49 @@ class Community {
     }
   }
 
+  public async deleteVerifyWalletChannel(guild_id: string) {
+    const res = await fetch(
+      `${API_BASE_URL}/verify/config?guild_id=${guild_id}`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    )
+    if (res.status !== 200) {
+      throw new Error(
+        `failed to delete verify wallet channel from guild ${guild_id}`
+      )
+    }
+
+    const json = await res.json()
+    if (json.error !== undefined) {
+      throw new Error(json.error)
+    }
+  }
+
+  public async getVerifyWalletChannel(guild_id: string) {
+    const res = await fetch(`${API_BASE_URL}/verify/config/${guild_id}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+    if (res.status !== 200 && res.status !== 400) {
+      throw new Error(
+        `failed to get verify wallet config from guild ${guild_id}`
+      )
+    }
+
+    const json = await res.json()
+    // throw all errors except 'record not found'
+    if (json.error !== undefined && !json.error.includes("record not found")) {
+      throw new Error(json.error)
+    }
+    return json
+  }
+
   public async giftXp(req: {
     admin_discord_id: string
     user_discord_id: string

--- a/src/commands/community/verify/create.ts
+++ b/src/commands/community/verify/create.ts
@@ -1,0 +1,46 @@
+import { Command } from "types/common"
+import community from "adapters/community"
+import { PREFIX } from "utils/constants"
+import { composeEmbedMessage } from "utils/discordEmbed"
+import { getCommandArguments } from "utils/commands"
+
+const command: Command = {
+  id: "verify_create",
+  command: "create",
+  brief: "Create verify wallet channel",
+  category: "Community",
+  run: async function (msg) {
+    const args = getCommandArguments(msg)
+    const channelId = args[2].slice(2, args[2].length - 1)
+
+    const createVerifyWalletRequest = {
+      verify_channel_id: channelId,
+      guild_id: msg.guildId,
+    }
+
+    await community.createVerifyWalletChannel(createVerifyWalletRequest)
+    return {
+      messageOptions: {
+        embeds: [
+          composeEmbedMessage(msg, {
+            title: "Verify wallet channel",
+            description: `Successfully created a channel for verifying wallet.`,
+          }),
+        ],
+      },
+    }
+  },
+  getHelpMessage: async (msg) => ({
+    embeds: [
+      composeEmbedMessage(msg, {
+        usage: `${PREFIX}verify create <channel>`,
+        examples: `${PREFIX}verify create #general`,
+      }),
+    ],
+  }),
+  canRunWithoutAction: true,
+  colorType: "Server",
+  minArguments: 3,
+}
+
+export default command

--- a/src/commands/community/verify/index.ts
+++ b/src/commands/community/verify/index.ts
@@ -1,10 +1,14 @@
 import { Command } from "types/common"
 import { PREFIX } from "utils/constants"
 import { composeEmbedMessage } from "utils/discordEmbed"
-import wallet from "./wallet"
+import create from "./create"
+import list from "./list"
+import remove from "./remove"
 
 const actions: Record<string, Command> = {
-  wallet,
+  create,
+  list,
+  remove,
 }
 
 const command: Command = {

--- a/src/commands/community/verify/list.ts
+++ b/src/commands/community/verify/list.ts
@@ -1,0 +1,49 @@
+import { Command } from "types/common"
+import community from "adapters/community"
+import { PREFIX } from "utils/constants"
+import { composeEmbedMessage } from "utils/discordEmbed"
+
+const command: Command = {
+  id: "verify_list",
+  command: "list",
+  brief: "show verify channel",
+  category: "Community",
+  run: async function (msg) {
+    const res = await community.getVerifyWalletChannel(msg.guildId)
+    if (res.error) {
+      return {
+        messageOptions: {
+          embeds: [
+            composeEmbedMessage(msg, {
+              title: "Verify wallet channel",
+              description: `Verify wallet channel is not set.`,
+            }),
+          ],
+        },
+      }
+    }
+    return {
+      messageOptions: {
+        embeds: [
+          composeEmbedMessage(msg, {
+            title: "Verify wallet channel",
+            description: `Verify wallet channel is config at <#${res.data.verify_channel_id}>.`,
+          }),
+        ],
+      },
+    }
+  },
+  getHelpMessage: async (msg) => ({
+    embeds: [
+      composeEmbedMessage(msg, {
+        usage: `${PREFIX}verify list`,
+        examples: `${PREFIX}verify list`,
+      }),
+    ],
+  }),
+  canRunWithoutAction: true,
+  colorType: "Server",
+  minArguments: 2,
+}
+
+export default command

--- a/src/commands/community/verify/remove.ts
+++ b/src/commands/community/verify/remove.ts
@@ -2,29 +2,20 @@ import { Command } from "types/common"
 import community from "adapters/community"
 import { PREFIX } from "utils/constants"
 import { composeEmbedMessage } from "utils/discordEmbed"
-import { getCommandArguments } from "utils/commands"
 
 const command: Command = {
-  id: "verify_wallet",
-  command: "wallet",
-  brief: "Verify user wallet",
+  id: "verify_remove",
+  command: "remove",
+  brief: "remove verify channel",
   category: "Community",
   run: async function (msg) {
-    const args = getCommandArguments(msg)
-    const channelId = args[2].slice(2, args[2].length - 1)
-
-    const createVerifyWalletRequest = {
-      verify_channel_id: channelId,
-      guild_id: msg.guildId,
-    }
-
-    await community.createVerifyWalletChannel(createVerifyWalletRequest)
+    await community.deleteVerifyWalletChannel(msg.guildId)
     return {
       messageOptions: {
         embeds: [
           composeEmbedMessage(msg, {
             title: "Verify wallet channel",
-            description: `Successfully created a channel for verifying wallet.`,
+            description: `Verify wallet channel successfully removed.`,
           }),
         ],
       },
@@ -33,14 +24,14 @@ const command: Command = {
   getHelpMessage: async (msg) => ({
     embeds: [
       composeEmbedMessage(msg, {
-        usage: `${PREFIX}verify wallet <channel>`,
-        examples: `${PREFIX}verify wallet #general`,
+        usage: `${PREFIX}verify remove`,
+        examples: `${PREFIX}verify remove`,
       }),
     ],
   }),
   canRunWithoutAction: true,
   colorType: "Server",
-  minArguments: 3,
+  minArguments: 2,
 }
 
 export default command


### PR DESCRIPTION
**What does this PR do?**

- Add 2 commands for `$verify`
- `$verify list` shows currently config verify wallet channel
- `$verify remove` delete currently config verify wallet channel
- Rename `$verify wallet` to `$verify create`

**Media (Loom or gif)**
<img width="373" alt="Screen Shot 2022-07-22 at 11 29 42" src="https://user-images.githubusercontent.com/84314071/180362752-fe39bcc4-8713-4913-9afe-a41e3f7c829f.png">

<img width="315" alt="Screen Shot 2022-07-22 at 11 30 11" src="https://user-images.githubusercontent.com/84314071/180362806-c33edc28-83e3-498f-ad6c-8c1372c6b3a3.png">

<img width="363" alt="Screen Shot 2022-07-22 at 11 31 52" src="https://user-images.githubusercontent.com/84314071/180362981-c3a97560-d0d2-4442-9989-0903874e69d6.png">

In case config channel is empty
<img width="280" alt="Screen Shot 2022-07-22 at 11 30 30" src="https://user-images.githubusercontent.com/84314071/180362839-759d1283-4a55-4a2d-b3e1-d57512b5b4cb.png">



