### PR TITLE
feat: config twitter api

### DIFF
--- a/src/adapters/config.ts
+++ b/src/adapters/config.ts
@@ -681,6 +681,34 @@ class Config {
     }
     return json.data
   }
+
+  public async createTwitterConfig(
+    guildid: string,
+    csmrKey: string,
+    csmrKeyScrt: string,
+    acsToken: string,
+    acsTokenScrt: string
+  ) {
+    const body = {
+      guild_id: guildid,
+      twitter_consumer_key: csmrKey,
+      twitter_consumer_secret: csmrKeyScrt,
+      twitter_access_token: acsToken,
+      twitter_access_token_secret: acsTokenScrt,
+    }
+    const res = await fetch(`${API_BASE_URL}/configs/twitter`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+    if (res.status !== 200) {
+      throw new Error(`failed to create twitter config`)
+    }
+
+    const json = await res.json()
+    if (json.error !== undefined) {
+      throw Error(json.error)
+    }
+  }
 }
 
 const config = new Config()

--- a/src/commands/community/nft/config.ts
+++ b/src/commands/community/nft/config.ts
@@ -1,0 +1,49 @@
+import { Command } from "types/common"
+import { PREFIX } from "utils/constants"
+import { composeEmbedMessage } from "utils/discordEmbed"
+import { getCommandArguments } from "utils/commands"
+import config from "adapters/config"
+
+const command: Command = {
+  id: "nft_config_twitter-sale",
+  command: "config twitter-sale",
+  brief: "Config twitter sales bot",
+  category: "Community",
+  run: async function (msg) {
+    const args = getCommandArguments(msg)
+    const csmrKey = args[3]
+    const csmrKeyScrt = args[4]
+    const acsToken = args[5]
+    const acsTokenScrt = args[6]
+    await config.createTwitterConfig(
+      msg.guildId,
+      csmrKey,
+      csmrKeyScrt,
+      acsToken,
+      acsTokenScrt
+    )
+    return {
+      messageOptions: {
+        embeds: [
+          composeEmbedMessage(msg, {
+            title: "Twitter sale config",
+            description: `Successfully set configs.`,
+          }),
+        ],
+      },
+    }
+  },
+  getHelpMessage: async (msg) => ({
+    embeds: [
+      composeEmbedMessage(msg, {
+        usage: `${PREFIX}nft config twitter-sale <consumer_key> <consumer_key_secret> <access_token> <access_token_secret>`,
+        examples: `${PREFIX}nft config twitter-sale J9ts... hNl8... 1450... POvv...`,
+      }),
+    ],
+  }),
+  canRunWithoutAction: false,
+  colorType: "Market",
+  minArguments: 5,
+}
+
+export default command

--- a/src/commands/community/nft/index.ts
+++ b/src/commands/community/nft/index.ts
@@ -8,6 +8,7 @@ import list from "./list"
 import recent from "./recent"
 import query from "./query"
 import stats from "./stats"
+import config from "./config"
 
 const actions: Record<string, Command> = {
   add,
@@ -16,6 +17,7 @@ const actions: Record<string, Command> = {
   list,
   recent,
   stats,
+  config,
 }
 
 const command: Command = {

--- a/src/env.ts
+++ b/src/env.ts
@@ -15,6 +15,8 @@ export const PT_API_SERVER_HOST =
   process.env.PT_API_SERVER_HOST || "https://backend.pod.so"
 
 export const LOG_CHANNEL_ID = process.env.LOG_CHANNEL_ID || "932579148608729118"
+export const SALE_CHANNEL_ID =
+  process.env.SALE_CHANNEL_ID || "1002254978360025149"
 export const MOCHI_GUILD_ID = process.env.MOCHI_GUILD_ID || "962589711841525780"
 export const GAME_TRIPOD_TEST_CHANNEL_ID = "884726476900036628"
 export const GAME_TRIPOD_CHANNEL_IDS = process.env.GAME_TRIPOD_CHANNEL_IDS || [

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,6 +1,6 @@
 import { Message } from "discord.js"
 import handlePrefixedCommand from "../commands"
-import { LOG_CHANNEL_ID } from "../env"
+import { LOG_CHANNEL_ID, MOCHI_GUILD_ID, SALE_CHANNEL_ID } from "../env"
 import { PREFIX, VALID_BOOST_MESSAGE_TYPES } from "utils/constants"
 import { Event } from "."
 import { logger } from "../logger"
@@ -17,18 +17,49 @@ export const handleNormalMessage = async (message: Message) => {
   const messageType = VALID_BOOST_MESSAGE_TYPES.includes(message.type)
     ? MessageTypes["USER_PREMIUM_GUILD_SUBSCRIPTION"]
     : MessageTypes["DEFAULT"]
-  const resp = await webhook.pushDiscordWebhook("messageCreate", {
-    author: {
-      id: message.author.id,
-    },
-    guild_id: message.guildId,
-    channel_id: message.channelId,
-    timestamp: message.createdAt,
-    content: message.content,
-    type: messageType,
-  })
 
-  if (resp.error !== undefined) {
+  let body, msg
+  if (
+    message.guildId === MOCHI_GUILD_ID &&
+    message.channelId === SALE_CHANNEL_ID &&
+    message.embeds.length !== 0
+  ) {
+    const regExpParen = /\(([^)]+)\)/ // match string inside ( )
+    const regExpBrac = /\[([^\]]+)\]/ // match string inside [ ]
+    const url = regExpParen.exec(message.embeds[0].fields[2].value)[1]
+    const marketplace = regExpBrac.exec(message.embeds[0].fields[2].value)[1]
+    const from = regExpBrac.exec(message.embeds[0].fields[4].value)[1]
+    const to = regExpBrac.exec(message.embeds[0].fields[5].value)[1]
+    const price = message.embeds[0].fields[7].value
+    const collection = message.embeds[0].author.name
+    const name = message.embeds[0].description.replace("sold!", "")
+    const image = message.embeds[0].image.url
+    body = {
+      token_name: name,
+      collection_name: collection,
+      price: price,
+      seller_address: from,
+      buyer_address: to,
+      marketplace: marketplace,
+      marketplace_url: url,
+      image: image,
+    }
+    msg = "salesCreate"
+  } else {
+    body = {
+      author: {
+        id: message.author.id,
+      },
+      guild_id: message.guildId,
+      channel_id: message.channelId,
+      timestamp: message.createdAt,
+      content: message.content,
+      type: messageType,
+    }
+    msg = "messageCreate"
+  }
+  const resp = await webhook.pushDiscordWebhook(msg, body)
+  if (resp.error != undefined) {
     logger.error(`failed to handle webhook: ${resp.error}`)
   }
 }
@@ -37,7 +68,11 @@ export default {
   name: "messageCreate",
   once: false,
   execute: async (message: Message) => {
-    if (message.channel.id === LOG_CHANNEL_ID || message.author.bot) return
+    if (
+      message.channel.id === LOG_CHANNEL_ID ||
+      (message.author.bot && message.channelId !== SALE_CHANNEL_ID)
+    )
+      return
 
     try {
       if (message.content.startsWith(PREFIX)) {


### PR DESCRIPTION
**What does this PR do?**

- New cmd `nft config twitter-sale <consumer_key> <consumer_key_secret> <access_token> <access_token_secret>` to set twitter sales bot
- Webhook works with bot message only in `#sales-feed` channel

