### PR TITLE
feat: twitter watch event

### DIFF
--- a/src/adapters/config.ts
+++ b/src/adapters/config.ts
@@ -711,6 +711,8 @@ class Config {
       channel_id: string
       user_id: string
       hashtag: Array<string>
+      twitter_username: Array<string>
+      rule_id: string
     }
   ) {
     const body = {
@@ -731,7 +733,7 @@ class Config {
     }
   }
 
-  public async getTwitterConfig(guildId: string) {
+  public async getTwitterConfig(guildId = "") {
     const res = await fetch(
       `${API_BASE_URL}/configs/twitter/hashtag/${guildId}`
     )
@@ -754,6 +756,27 @@ class Config {
     )
     if (res.status !== 200) {
       throw new Error(`failed to remove twitter config`)
+    }
+
+    const json = await res.json()
+    if (json.error !== undefined) {
+      throw Error(json.error)
+    }
+  }
+
+  public async logTweet(data: {
+    twitter_id: string
+    twitter_handle: string
+    tweet_id: string
+    guild_id: string
+  }) {
+    const res = await fetch(`${API_BASE_URL}/twitter`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+
+    if (res.status !== 200) {
+      throw new Error("failed to log tweet")
     }
 
     const json = await res.json()

--- a/src/commands/config/poe/twitter/index.ts
+++ b/src/commands/config/poe/twitter/index.ts
@@ -1,56 +1,11 @@
-import config from "adapters/config"
 import { Command } from "types/common"
 import { PREFIX } from "utils/constants"
 import { composeEmbedMessage } from "utils/discordEmbed"
 import set from "./set"
 import list from "./list"
 import remove from "./remove"
-import { twitter } from "utils/twitter-api"
 import { Message } from "discord.js"
-import { getEmoji } from "utils/common"
 import { getCommandArguments } from "utils/commands"
-import { logger } from "logger"
-
-const hashtagReg = new RegExp(/#[a-z0-9_]+/gim)
-const twitterIdReg = new RegExp(
-  /(http|https):\/\/twitter.com\/.*\/status\/(\d*)/gim
-)
-
-function lower(ht: string) {
-  return ht.toLowerCase()
-}
-
-function getTweetId(content: string) {
-  twitterIdReg.lastIndex = 0
-  return twitterIdReg.exec(content)?.[2]
-}
-
-function getHashtags(tweetContent: string) {
-  const results = []
-  let match
-  while ((match = hashtagReg.exec(tweetContent)) !== null) {
-    results.push(match[0])
-  }
-  return results
-}
-
-export async function handleNewTweet(msg: Message) {
-  const twitterConfig = await config.getTwitterConfig(msg.guildId)
-  if (twitterConfig?.channel_id !== msg.channelId) return
-  const content = msg.content
-  const tweetId = getTweetId(content)
-  if (!tweetId) return
-  const tweet = await twitter.tweets.findTweetById(tweetId)
-  if (!tweet.errors && tweet.data) {
-    const hashtags = getHashtags(tweet.data.text).map(lower)
-    const triggerHashtags = twitterConfig.hashtag.map(lower)
-    const found = hashtags.filter((ht) => triggerHashtags.includes(ht))
-    if (found.length > 0) {
-      msg.react(getEmoji("approve")).catch(() => msg.react("✅"))
-      logger.info(`[poe/twitter]: trigger for post ${msg.url}`)
-    }
-  }
-}
 
 const actions: Record<string, Command> = {
   set,

--- a/src/commands/config/poe/twitter/list.ts
+++ b/src/commands/config/poe/twitter/list.ts
@@ -38,9 +38,13 @@ const command: Command = {
               twitterConfig.updated_at
             )
               .utc()
-              .format("MMM DD YYYY HH:mm:ss UTC")})\nWatching <#${
+              .format("MMM DD YYYY HH:mm:ss UTC")})\nCheck updates in <#${
               twitterConfig.channel_id
-            }>\nFor tags: ${twitterConfig.hashtag
+            }>\nTags: ${twitterConfig.hashtag
+              .filter((k: string) => k.startsWith("#"))
+              .map((t: string) => `\`${t}\``)
+              .join(", ")}\nMentions: ${twitterConfig.twitter_username
+              .filter((k: string) => k.startsWith("@"))
               .map((t: string) => `\`${t}\``)
               .join(", ")}`,
           }),

--- a/src/commands/config/poe/twitter/remove.ts
+++ b/src/commands/config/poe/twitter/remove.ts
@@ -3,6 +3,7 @@ import { Command } from "types/common"
 import { getEmoji } from "utils/common"
 import { PREFIX } from "utils/constants"
 import { composeEmbedMessage } from "utils/discordEmbed"
+import TwitterStream from "utils/TwitterStream"
 
 const command: Command = {
   id: "poe_twitter_remove",
@@ -11,7 +12,13 @@ const command: Command = {
   category: "Config",
   onlyAdministrator: true,
   run: async function (msg) {
+    const twitterConfig = await config.getTwitterConfig(msg.guildId)
     await config.removeTwitterConfig(msg.guildId)
+
+    await TwitterStream.removeRule({
+      channelId: twitterConfig.channel_id,
+      ruleId: twitterConfig.rule_id,
+    })
 
     msg.react(getEmoji("approve")).catch(() => msg.react("✅"))
 

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -10,7 +10,6 @@ import CommandChoiceManager from "utils/CommandChoiceManager"
 import webhook from "adapters/webhook"
 import { MessageTypes } from "discord.js/typings/enums"
 import { handlePlayTripod } from "commands/games/tripod"
-import { handleNewTweet } from "commands/config/poe/twitter"
 
 export const handleNormalMessage = async (message: Message) => {
   if (message.channel.type === "DM") return
@@ -85,7 +84,6 @@ export default {
       }
       await handleNormalMessage(message)
       handlePlayTripod(message)
-      handleNewTweet(message)
     } catch (e) {
       const error = e as BotBaseError
       if (error.handle) {

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -8,6 +8,7 @@ import client from "../index"
 import { invites } from "./index"
 import { BotBaseError } from "errors"
 import { setTimeout as wait } from "timers/promises"
+import TwitterStream from "utils/TwitterStream"
 
 export default {
   name: "ready",
@@ -52,6 +53,9 @@ export default {
       }
       ChannelLogger.log(error, 'Event<"ready">')
     }
+
+    // set the client so the bot can send message
+    TwitterStream.client = listener
   },
 } as Event<"ready">
 

--- a/src/types/InmemoryStorage.ts
+++ b/src/types/InmemoryStorage.ts
@@ -1,0 +1,9 @@
+/*
+ * InmemoryStorage is a class to use where you want to store data for caching purpose
+ * however since this is only in memory (data loss after restart), you must implement
+ * the `up` method to properly populate the data when the server starts
+ * the implementation logic is to you (asynchronous fetch, reading from a file, etc...)
+ */
+export abstract class InmemoryStorage {
+  protected abstract up(): Promise<void>
+}

--- a/src/utils/TwitterStream.ts
+++ b/src/utils/TwitterStream.ts
@@ -1,0 +1,208 @@
+import apiConfig from "adapters/config"
+import { Client, TextChannel } from "discord.js"
+import { InmemoryStorage } from "types/InmemoryStorage"
+import { twitter } from "utils/twitter-api"
+import { logger } from "logger"
+
+type UpsertRuleParams = {
+  ruleValue: string[]
+  channelId: string
+  guildId: string
+  ruleId?: string
+}
+
+type RemoveRuleParams = {
+  ruleId: string
+  channelId: string
+}
+
+type Tweet = {
+  data?: { author_id?: string; id: string }
+  includes?: { users?: Array<{ id: string; username: string }> }
+  matching_rules?: Array<{ id: string }>
+}
+
+type ProcessParam = {
+  channel: TextChannel
+  handle: string
+  tweet: Tweet
+}
+
+function toTwitterRuleFormat(keywords: Array<string>) {
+  return `(${keywords.filter(Boolean).join(" OR ")}) -is:retweet`
+}
+
+class TwitterStream extends InmemoryStorage {
+  private publishChannelsByRuleId: Record<string, Set<string>> = {}
+  private _client: Client
+
+  constructor() {
+    super()
+    this.up()
+    this.watchStream()
+  }
+
+  set client(c: Client) {
+    if (this._client?.isReady) return
+    this._client = c
+  }
+
+  get client() {
+    return this._client
+  }
+
+  private async sendToChannel({ channel, handle, tweet }: ProcessParam) {
+    await channel.send(`https://twitter.com/${handle}/status/${tweet.data?.id}`)
+    logger.info(
+      `[TwitterStream]: tweet ${tweet.data?.id} of ${handle} sent to channel`
+    )
+  }
+
+  private async logToDB({ channel, tweet, handle }: ProcessParam) {
+    await apiConfig.logTweet({
+      guild_id: channel.guildId,
+      tweet_id: tweet.data?.id,
+      twitter_id: tweet.data?.author_id,
+      twitter_handle: handle,
+    })
+    logger.info(
+      `[TwitterStream]: tweet ${tweet.data?.id} of ${handle} logged to db`
+    )
+  }
+
+  private async process(data: ProcessParam) {
+    Promise.all([this.sendToChannel(data), this.logToDB(data)]).then(() => {
+      logger.info(
+        `[TwitterStream]: tweet ${data.tweet.data?.id} of ${data.handle} processed`
+      )
+    })
+  }
+
+  private async handle(tweet: Tweet) {
+    const ruleIds = tweet.matching_rules?.map((mr) => mr.id) ?? []
+    const handle = tweet.includes?.users?.find(
+      (u) => u.id === tweet.data?.author_id
+    )?.username
+    if (ruleIds.length === 0 || !handle || !tweet.data?.id) return
+    logger.info(`[TwitterStream]: handling tweet ${tweet.data?.id}`)
+    const publishChannels = []
+    for (const ruleId of ruleIds) {
+      if (this.publishChannelsByRuleId[ruleId]) {
+        publishChannels.push(this.publishChannelsByRuleId[ruleId])
+      }
+    }
+
+    publishChannels.forEach((channelIds) => {
+      channelIds.forEach((channelId) => {
+        this.client.channels.fetch(channelId).then((channel) => {
+          // `channel` should be TextChannel, if not then it's probably removed -> warn
+          if (channel.isText() && channel instanceof TextChannel) {
+            this.process({ channel, tweet, handle })
+          } else {
+            logger.warn(
+              `[TwitterStream]: matched tweet id ${tweet.data?.id} but unable to process due to removed channel id ${channel.id}`
+            )
+          }
+        })
+      })
+    })
+  }
+
+  private async watchStream() {
+    const stream = twitter.tweets.searchStream({
+      expansions: ["author_id"],
+    })
+    for await (const tweet of stream) {
+      this.handle(tweet)
+    }
+  }
+
+  /*
+   * For detail on how to build a rule, see
+   * https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/integrate/build-a-rule
+   */
+  async upsertRule(params: UpsertRuleParams) {
+    let ruleId = params.ruleId
+    // if there is a ruleId, it means that we are updating a current rule -> need to call twitter API
+    // or else we will be listening to stale rules in the same guild
+    if (ruleId) {
+      await twitter.tweets.addOrDeleteRules({
+        delete: {
+          ids: [ruleId],
+        },
+      })
+    }
+    const rule = await twitter.tweets.addOrDeleteRules({
+      add: [
+        {
+          value: toTwitterRuleFormat(params.ruleValue),
+        },
+      ],
+    })
+    if (rule.errors?.[0]?.title === "DuplicateRule") {
+      ruleId = (rule.errors?.[0] as { id?: string }).id
+    } else {
+      ruleId = rule.data[0].id
+    }
+    const publishChannels = this.publishChannelsByRuleId[ruleId] ?? new Set()
+    publishChannels.add(params.channelId)
+    this.publishChannelsByRuleId[ruleId] = publishChannels
+    return ruleId
+  }
+
+  async removeRule(params: RemoveRuleParams) {
+    await twitter.tweets.addOrDeleteRules({
+      delete: {
+        ids: [params.ruleId],
+      },
+    })
+    const set = this.publishChannelsByRuleId[params.ruleId]
+    if (!set) return
+    set.delete(params.channelId)
+  }
+
+  protected async up() {
+    logger.info("[TwitterStream] - backend retrieving data...")
+    let allRules = await twitter.tweets.getRules()
+    const allRuleIds = allRules.data?.filter((r) => r.id).map((r) => r.id) ?? []
+    const allTwitterConfig = await apiConfig.getTwitterConfig()
+    const promises = allTwitterConfig.map(
+      async (config: {
+        rule_id: string
+        channel_id: string
+        guild_id: string
+        user_id: string
+        hashtag: Array<string>
+        twitter_username: Array<string>
+      }) => {
+        const newRuleId = await this.upsertRule({
+          ruleValue: [...config.hashtag, ...config.twitter_username],
+          guildId: config.guild_id,
+          channelId: config.channel_id,
+          ruleId: config.rule_id,
+        })
+        await apiConfig.setTwitterConfig(config.guild_id, {
+          ...config,
+          rule_id: newRuleId,
+        })
+
+        return newRuleId
+      }
+    )
+    const validRuleIds = await Promise.all(promises)
+    const staleRuleIds = allRuleIds.filter(
+      (rid) => !validRuleIds.some((vrid) => vrid === rid)
+    )
+    allRules = await twitter.tweets.getRules()
+    if (staleRuleIds.length > 0) {
+      await twitter.tweets.addOrDeleteRules({
+        delete: {
+          ids: staleRuleIds,
+        },
+      })
+    }
+    logger.info("[TwitterStream] - backend retrieving data OK")
+  }
+}
+
+export default new TwitterStream()


### PR DESCRIPTION
**What does this PR do?**

-   [x] Add Twitter watch event feature: user setup a twitter config in discord to detect for tweets that has hashtag or user mention -> log tweet if detected and post link into discord channel

**How to test**

-   In discord text channel, enter `$poe twitter set #general #some_hashtag`
-   Go to twitter, tweet something with the `#some_hashtag` hashtag
-   After a brief delay, discord bot will post the link of that tweet into the channel `#general`

**Edge cases**

Note: The discord bot restarts regularly every time the team release a new version, this PR introduces a new abstract class called `InmemoryStorage`: subclass extending `InmemoryStorage` will need to implement the `up` method which are responsible for restoring the state when the bot starts

-   Some edge cases including: (all of which will be handled by the `up` method)
    1. The twitter config changes during the bot offline
    2. The twitter config is removed during the bot offline

**Media (Loom or gif)**
- Logging when new tweet is detected and handled
<img width="1275" alt="logging when new tweet detected" src="https://user-images.githubusercontent.com/25856620/184030189-3ffa5426-dd12-4072-ba7d-b737cf71a8fa.png">

- Logging when restoring data
<img width="983" alt="CleanShot 2022-08-11 at 03 09 02@2x" src="https://user-images.githubusercontent.com/25856620/184030322-c2f9fbe3-8369-4bd8-aef7-d3c254f923db.png">

