### PR TITLE
feat: add nft view for profile command

### DIFF
--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -1,432 +1,343 @@
 import profile from "adapters/profile"
-import { Message, MessageAttachment } from "discord.js"
-import { Command } from "types/common"
-import { UserProfile, UserXps } from "types/profile"
-import { composeEmbedMessage } from "utils/discordEmbed"
-import * as Canvas from "canvas"
 import {
-  drawProgressBar,
-  heightOf,
-  widthOf,
-  fillWrappedText,
-  calculateWrapperTextHeight,
-  drawDivider,
-  drawCircleImage,
-} from "utils/canvas"
-import { drawRectangle } from "utils/canvas"
-import { CircleleStats, RectangleStats, TextStats } from "types/canvas"
-import { PREFIX } from "utils/constants"
-import { emojis, getEmojiURL, msgColors } from "utils/common"
+  Message,
+  MessageActionRow,
+  MessageSelectMenu,
+  EmbedFieldData,
+  MessageOptions,
+  MessageSelectOptionData,
+} from "discord.js"
+import { Command } from "types/common"
+import {
+  composeEmbedMessage,
+  getErrorEmbed,
+  getPaginationRow,
+  justifyEmbedFields,
+  listenForPaginateAction,
+} from "utils/discordEmbed"
+import { DOT, PREFIX } from "utils/constants"
+import { getEmoji, capitalizeFirst, isValidHttpUrl } from "utils/common"
+import { MessageComponentTypes } from "discord.js/typings/enums"
+import { NFTMetadataAttrIcon } from "types/profile"
 
-const fractionXpTitles: Record<string, string> = {
-  NOBILITY_XP: "Imperio",
-  FAME_XP: "Rebellio",
-  LOYALTY_XP: "Mercanto",
-  REPUTATION_XP: "Academia",
+const rarityColors: Record<string, string> = {
+  COMMON: "#939393",
+  UNCOMMON: "#22d489",
+  RARE: "#02b3ff",
+  EPIC: "#9802f6",
+  LEGENDARY: "#ff8001",
+  MYTHIC: "#ed2939",
 }
 
-const fractionXpColors: Record<string, string> = {
-  NOBILITY_XP: "#EDDEA7",
-  FAME_XP: "#EFB88B",
-  LOYALTY_XP: "#9EFFE8",
-  REPUTATION_XP: "#C2E6FF",
+function getRarityEmoji(rarity: string) {
+  const rarities = Object.keys(rarityColors)
+  rarity = rarities[rarities.indexOf(rarity.toUpperCase())] ?? "common"
+  return Array.from(Array(4).keys())
+    .map((k) => getEmoji(`${rarity}${k + 1}`))
+    .join("")
 }
 
-async function drawFractionProgressBar(
-  ctx: Canvas.CanvasRenderingContext2D,
-  container: RectangleStats,
-  rootComponent: TextStats,
-  xps: UserXps
+function getIcon(iconList: NFTMetadataAttrIcon[], iconName: string): string {
+  if (!iconList) {
+    return getEmoji(iconName)
+  }
+  const icon = iconList.find((i) => i.trait_type === iconName)
+
+  if (icon) {
+    return icon.discord_icon
+  }
+
+  return getEmoji(iconName)
+}
+
+function selectCollectionComponent(
+  collections: {
+    name: string
+    collectionAddress: string
+    default: boolean
+  }[]
 ) {
-  const fXpTitle = {
-    x: rootComponent.x,
-    y: rootComponent.y + rootComponent.mb,
-    mb: 20,
-  }
-  const fractionPgBar: RectangleStats = {
-    x: {
-      from: fXpTitle.x,
-      to: 0,
-    },
-    y: {
-      from: fXpTitle.y + fXpTitle.mb,
-      to: 0,
-    },
-    w: 0,
-    h: 40,
-    radius: 10,
-    overlayColor: "white",
-    mb: 10,
-    mr: 50,
-  }
-  fractionPgBar.w = (container.w - fractionPgBar.mr - container.pl * 2) / 2
-  const fXpProgress = {
-    x: fractionPgBar.x.from,
-    y: 0,
-    mb: 60,
-  }
-  Object.entries(xps).forEach(([k, xp], i) => {
-    // title
-    ctx.font = "bold 34px Manrope"
-    const fXpTitleStr = `${fractionXpTitles[k.toUpperCase()]}`
-    ctx.fillText(fXpTitleStr, fXpTitle.x, fXpTitle.y)
-
-    // pg bar
-    const baseXp = Math.floor(xp / 1000) * 1000
-    let targetXp = Math.max(Math.ceil(xp / 1000) * 1000, 1000)
-    targetXp += targetXp === baseXp ? 1000 : 0
-    const fractionPg = (xp - baseXp) / (targetXp - baseXp)
-
-    fractionPgBar.overlayColor = fractionXpColors[k.toUpperCase()]
-    fractionPgBar.x.to = fractionPgBar.x.from + fractionPgBar.w
-    fractionPgBar.y.to = fractionPgBar.y.from + fractionPgBar.h
-    drawProgressBar(ctx, fractionPgBar, fractionPg)
-
-    // progress
-    ctx.font = "31px Manrope"
-    const fXpProgressStr = `${xp} / ${targetXp}`
-    fXpProgress.x = fractionPgBar.x.to - widthOf(ctx, fXpProgressStr)
-    fXpProgress.y = fXpTitle.y
-    ctx.fillText(fXpProgressStr, fXpProgress.x, fXpProgress.y)
-
-    if (i % 2 === 0) {
-      // stats for right components
-      fXpTitle.x = fractionPgBar.x.to + fractionPgBar.mr
-      fractionPgBar.x = {
-        from: fXpTitle.x,
-        to: fXpTitle.x + fractionPgBar.w,
-      }
-      fXpProgress.x = fXpTitle.x
-      return
-    }
-
-    // stats for left components
-    fXpTitle.x = rootComponent.x
-    fractionPgBar.x = {
-      from: fXpTitle.x,
-      to: fXpTitle.x + fractionPgBar.w,
-    }
-    fXpProgress.x = fXpTitle.x
-    fXpTitle.y = fractionPgBar.y.to + fXpProgress.mb
-    fractionPgBar.y.from = fXpTitle.y + fXpTitle.mb
-    fractionPgBar.y.to = fractionPgBar.y.from + fractionPgBar.h
-    fXpProgress.y =
-      fractionPgBar.y.to + fractionPgBar.mb + heightOf(ctx, fXpProgressStr)
+  const options: MessageSelectOptionData[] = []
+  collections.forEach((collection) => {
+    options.push({
+      label: collection.name,
+      description: `${collection.name} collection`,
+      value: collection.collectionAddress,
+      default: collection.default,
+    })
   })
+
+  const row = new MessageActionRow().addComponents(
+    new MessageSelectMenu()
+      .setCustomId("selectCollection")
+      .setPlaceholder("Other collections...")
+      .addOptions(options)
+  )
+  return row
 }
 
-async function renderProfile(msg: Message, data: UserProfile) {
-  let withFractionXp = data.guild?.global_xp
-  let ptProfile
-  if (data.guild?.global_xp) {
-    ptProfile = await profile.getPodTownUser(msg.author.id)
-  }
-  withFractionXp = withFractionXp && !!ptProfile && ptProfile.is_verified
+function selectOtherViewComponent(defaultValue?: string) {
+  const row = new MessageActionRow().addComponents(
+    new MessageSelectMenu()
+      .setCustomId("selectView")
+      .setPlaceholder("Other views...")
+      .addOptions([
+        {
+          label: "My NFT Collections",
+          description: "NFT details",
+          value: "nft",
+          default: defaultValue == "nft",
+        },
+        {
+          label: "My profile",
+          description: "My Profile Info",
+          value: "profile",
+          default: defaultValue == "profile",
+        },
+      ])
+  )
+  return row
+}
 
-  const container = {
-    x: {
-      from: 0,
-      to: withFractionXp ? 1200 : 900,
-    },
-    y: {
-      from: 0,
-      to: withFractionXp ? 900 : 620,
-    },
-    w: 0,
-    h: 0,
-    pl: 40,
-    pt: 45,
-    // bgColor: "#303137",
-    bgColor: "#2F3136",
-    radius: 30,
+function buildProgressbar(progress: number): string {
+  const progressBar = [
+    getEmoji("BAR_1_EMPTY"),
+    getEmoji("BAR_2_EMPTY"),
+    getEmoji("BAR_2_EMPTY"),
+    getEmoji("BAR_2_EMPTY"),
+    getEmoji("BAR_2_EMPTY"),
+    getEmoji("BAR_3_EMPTY"),
+  ]
+  const maxBar = 6
+  const progressOutOfMaxBar = Math.round(progress * maxBar)
+  for (let i = 0; i <= progressOutOfMaxBar; ++i) {
+    if (progressOutOfMaxBar == 0) break
+    let barEmote = "BAR_2_FULL"
+    if (i == 1) {
+      barEmote = i == progressOutOfMaxBar ? "BAR_1_MID" : "BAR_1_FULL"
+    } else if (i > 1 && i < maxBar) {
+      barEmote = i == progressOutOfMaxBar ? "BAR_2_MID" : "BAR_2_FULL"
+    } else {
+      barEmote = i == progressOutOfMaxBar ? "BAR_3_MID" : "BAR_3_FULL"
+    }
+    progressBar[i - 1] = getEmoji(barEmote, true)
   }
-  container.w = container.x.to - container.x.from
-  // add container if long aboutme
+  return progressBar.join("")
+}
+
+async function composeMyProfileEmbed(msg: Message): Promise<MessageOptions> {
+  const userProfile = await profile.getUserProfile(msg.guildId, msg.author.id)
   const aboutMeStr =
-    data.about_me.trim().length === 0
+    userProfile.about_me.trim().length === 0
       ? "I'm a mysterious person"
-      : data.about_me
-  const oneLineHeight = calculateWrapperTextHeight(
-    "Sample text",
-    "33px Manrope",
-    container.w - container.pl * 2
-  )
-  const aboutmeHeight = calculateWrapperTextHeight(
-    aboutMeStr,
-    "33px Manrope",
-    container.w - container.pl * 2
-  )
-  const additionalHeight = Math.max(aboutmeHeight - oneLineHeight, 0)
-  container.y.to += additionalHeight
-  container.h = container.y.to - container.y.from
-  const canvas = Canvas.createCanvas(container.w, container.h)
-  const ctx = canvas.getContext("2d")
+      : userProfile.about_me
 
-  // background
-  ctx.save()
-  drawRectangle(ctx, container, container.bgColor)
-  ctx.clip()
-  ctx.restore()
-
-  // avatar
-  const avatar: CircleleStats = {
-    x: container.pl,
-    y: container.pt,
-    radius: 82,
-    mr: 40,
-    mb: 50,
-  }
-  avatar.x += avatar.radius
-  avatar.y += avatar.radius
-  await drawCircleImage({
-    ctx,
-    stats: avatar,
-    imageURL: msg.author.displayAvatarURL({ format: "jpeg" }),
-  })
-
-  // username
-  ctx.fillStyle = "white"
-  ctx.font = "bold 39px Manrope"
-  const username = {
-    w: widthOf(ctx, msg.author.username),
-    h: heightOf(ctx, msg.author.username),
-    x: container.pl + avatar.radius * 2 + avatar.mr,
-    y: container.pt + heightOf(ctx, msg.author.username),
-    mb: 25,
-    mr: 15,
-  }
-  ctx.fillText(msg.author.username, username.x, username.y)
-
-  // discriminator
-  ctx.save()
-  ctx.font = "30px Manrope"
-  ctx.fillStyle = "#8B8B8B"
-  const discriminator = {
-    x: username.x + username.w + username.mr,
-    y: username.y,
-  }
-  ctx.fillStyle = "#dcdfe3"
-  ctx.fillText(`#${msg.author.discriminator}`, discriminator.x, discriminator.y)
-  ctx.restore()
-
-  // rank title
-  ctx.save()
-  ctx.font = "bold 33px Manrope"
-  const rankTitleStr = "Rank:  "
-  const rankStr = `#${
-    data.guild_rank < 10 ? `0${data.guild_rank}` : `${data.guild_rank}`
-  }`
-  const rankTitle = {
-    x: container.w - container.pl - widthOf(ctx, `${rankTitleStr}${rankStr}`),
-    y: username.y,
-  }
-  ctx.fillStyle = "white"
-  ctx.fillText(rankTitleStr, rankTitle.x, rankTitle.y)
-
-  // rank
-  ctx.font = "33px Manrope"
-  const rank = {
-    x: rankTitle.x + widthOf(ctx, rankTitleStr),
-    y: username.y,
-  }
-  ctx.fillStyle = "#bfbfbf"
-  ctx.fillText(rankStr, rank.x, rank.y)
-  ctx.restore()
-
-  // divider
-  const divider = {
-    x: {
-      from: username.x,
-      to: container.w - container.pl,
-    },
-    y: username.y + username.mb,
-    mb: 25,
-  }
-  drawDivider(ctx, divider.x.from, divider.x.to, divider.y)
-
-  // level
-  ctx.font = "bold 33px Manrope"
-  const lvlStr = `Level ${data.current_level.level}`
-  const lvl = {
-    x: username.x,
-    y: divider.y + divider.mb + heightOf(ctx, lvlStr),
-    mb: 15,
-  }
-  ctx.fillStyle = "white"
-  ctx.fillText(lvlStr, lvl.x, lvl.y)
-
-  // XP
-  const xpStr = `${data.guild_xp}/${
-    data.next_level.min_xp ? data.next_level.min_xp : data.current_level.min_xp
-  }`
-  const xp = {
-    x: container.w - container.pl - widthOf(ctx, `${xpStr}`),
-    y: lvl.y,
-    ml: 30,
-  }
-  ctx.font = "33px Manrope"
-  ctx.fillStyle = "#BFBFBF"
-  ctx.fillText(xpStr, xp.x, xp.y)
-
-  // XP Title
-  const xpTitleStr = "XP:  "
-  const xpIcon = {
-    image: await Canvas.loadImage(getEmojiURL(emojis.ENERGY)),
-    h: 35,
-    w: 25,
-    x: xp.x - xp.ml,
-    y: xp.y - heightOf(ctx, xpTitleStr) - 5,
-  }
-  ctx.drawImage(xpIcon.image, xpIcon.x, xpIcon.y, xpIcon.w, xpIcon.h)
-  const xpTitle = {
-    x: xp.x - xp.ml - widthOf(ctx, xpTitleStr),
-    y: lvl.y,
-  }
-  ctx.fillStyle = "white"
-  ctx.font = "bold 33px Manrope"
-  ctx.fillText(xpTitleStr, xpTitle.x, xpTitle.y)
-
-  // XP progress bar
-  const pgBar: RectangleStats = {
-    x: {
-      from: username.x,
-      to: container.w - container.pl,
-    },
-    y: {
-      from: lvl.y + lvl.mb,
-      to: 0,
-    },
-    w: 0,
-    h: 40,
-    radius: 10,
-    overlayColor: msgColors.PRIMARY.toString(),
-    mb: 10,
-  }
-  pgBar.w = pgBar.x.to - pgBar.x.from
-  pgBar.y.to = pgBar.y.from + pgBar.h
-  drawProgressBar(ctx, pgBar, data.progress)
-
-  // aboutme title
-  const aboutMeTitleStr = "About me"
-  const aboutMeTitle = {
-    x: container.pl,
-    // y: actTitle.y + actTitle.mb,
-    y:
-      container.pt +
-      avatar.radius * 2 +
-      avatar.mb +
-      heightOf(ctx, aboutMeTitleStr),
-    mb: 45,
-  }
-  ctx.fillText(aboutMeTitleStr, aboutMeTitle.x, aboutMeTitle.y)
-
-  // aboutme
-  ctx.save()
-  ctx.font = "33px Manrope"
-  const aboutMe = {
-    x: aboutMeTitle.x,
-    y: aboutMeTitle.y + aboutMeTitle.mb,
-    mb: 80,
-  }
-  // last line y-coordinate
-  aboutMe.y = fillWrappedText(
-    ctx,
-    aboutMeStr,
-    aboutMe.x,
-    aboutMe.y,
-    container.w - container.pl * 2
-  )
-  ctx.restore()
-
-  // Address title
-  const addressTitleStr = "Address"
-  const addressTitle = {
-    x: aboutMeTitle.x,
-    y: aboutMe.y + aboutMe.mb,
-    mb: 45,
-  }
-  ctx.fillText(addressTitleStr, addressTitle.x, addressTitle.y)
-
-  // wallet address
-  ctx.save()
-  ctx.fillStyle = "#0DB4FB"
-  ctx.font = "33px Manrope"
-  let addressStr = data.user_wallet?.address
+  let addressStr = userProfile.user_wallet?.address
   if (!addressStr || !addressStr.length) {
-    ctx.fillStyle = "#BFBFBF"
     addressStr = "N/A"
   }
-  const address = {
-    x: addressTitle.x,
-    y: addressTitle.y + addressTitle.mb,
-    mb: 80,
-  }
-  ctx.fillText(addressStr, address.x, address.y)
-  ctx.restore()
 
-  // role title
-  const roleTitleStr = "Role"
-  const roleTitle = {
-    x: address.x,
-    y: address.y + address.mb,
-    mb: 45,
-  }
-  ctx.fillText(roleTitleStr, roleTitle.x, roleTitle.y)
+  const lvlStr = `\`${userProfile.current_level.level}\``
+  const lvlMax = 60
+  const levelProgress = buildProgressbar(
+    userProfile.current_level.level / lvlMax
+  )
+  const nextLevelMinXp = userProfile.next_level.min_xp
+    ? userProfile.next_level.min_xp
+    : userProfile.current_level.min_xp
 
-  // role
-  ctx.save()
+  const xpProgress = buildProgressbar(userProfile.guild_xp / nextLevelMinXp)
+
+  const xpStr = `\`${userProfile.guild_xp}/${
+    userProfile.next_level.min_xp
+      ? userProfile.next_level.min_xp
+      : userProfile.current_level.min_xp
+  }\``
+
+  const walletValue = "Wallet: `NA`"
+  const protocolValue = "Protocol: `NA`"
+  const nftValue = "NFT: `NA`"
+  const assetsStr = `${walletValue}\n${protocolValue}\n${nftValue}`
   const highestRole =
     msg.member.roles.highest.name !== "@everyone"
       ? msg.member.roles.highest
       : null
-  ctx.fillStyle = highestRole?.hexColor ?? "white"
-  const roleStr = highestRole?.name ?? "N/A"
-  const role = {
-    x: roleTitle.x,
-    y: roleTitle.y + roleTitle.mb,
-    mb: 80,
-  }
-  ctx.fillText(roleStr, role.x, role.y)
-  ctx.restore()
 
-  // activity title
-  const activityTitleStr = "Activities"
-  const pgBarWidth = (container.w - 50 - container.pl * 2) / 2
-  const activityTitle = {
-    x: role.x + pgBarWidth + 50,
-    y: roleTitle.y,
-    mb: 45,
-  }
-  ctx.fillText(activityTitleStr, activityTitle.x, activityTitle.y)
+  const roleStr = `\`${highestRole?.name ?? "N/A"}\``
+  const activityStr = `${getEmoji("FLAG")} \`${userProfile.nr_of_actions}\``
+  const rankStr = `:trophy: \`${userProfile.guild_rank ?? 0}\``
 
-  // activity
-  ctx.save()
-  const activityStr = `${data.nr_of_actions}`
-  const flagIcon = {
-    image: await Canvas.loadImage(getEmojiURL(emojis.FLAG)),
-    h: 30,
-    w: 25,
-    x: activityTitle.x,
-    y: activityTitle.y + 15,
-    mr: 7,
-  }
-  ctx.drawImage(flagIcon.image, flagIcon.x, flagIcon.y, flagIcon.w, flagIcon.h)
-  ctx.fillStyle = "#BFBFBF"
-  ctx.font = "33px Manrope"
-  ctx.fillText(
-    activityStr,
-    flagIcon.x + flagIcon.w + flagIcon.mr,
-    activityTitle.y + activityTitle.mb
+  const embed = composeEmbedMessage(msg, {
+    thumbnail: msg.author.displayAvatarURL(),
+    author: [`${msg.author.username}'s profile`, msg.author.displayAvatarURL()],
+  }).addFields(
+    {
+      name: "Level",
+      value: `${lvlStr} \n ${levelProgress}`,
+      inline: true,
+    },
+    {
+      name: "Experience",
+      value: `${xpStr} \n ${xpProgress}`,
+      inline: true,
+    },
+    {
+      name: "Assets",
+      value: assetsStr,
+      inline: true,
+    },
+    { name: "About me", value: aboutMeStr },
+    { name: "Address", value: addressStr },
+    { name: "Role", value: roleStr, inline: true },
+    { name: "Activities", value: activityStr, inline: true },
+    { name: "Rank", value: rankStr, inline: true }
   )
-  ctx.restore()
 
-  // fraction XPs
-  if (withFractionXp) {
-    const { xps } = ptProfile
-    await drawFractionProgressBar(ctx, container, role, xps)
+  return {
+    embeds: [embed],
+    components: [selectOtherViewComponent("profile")],
+  }
+}
+
+async function composeMyNFTEmbed(
+  msg: Message,
+  collectionAddress?: string,
+  page = 0
+): Promise<MessageOptions> {
+  const userProfile = await profile.getUserProfile(msg.guildId, msg.author.id)
+  let userAddress = userProfile.user_wallet?.address
+  if (!userAddress || !userAddress.length) {
+    userAddress = "N/A"
   }
 
-  return new MessageAttachment(canvas.toBuffer(), "profile.png")
+  const { data: userNftCollections } = await profile.getUserNFTCollection({
+    userAddress,
+  })
+
+  if (userNftCollections.length === 0) {
+    const embed = composeEmbedMessage(msg, {
+      author: [
+        `${msg.author.username}'s NFT collection`,
+        msg.author.displayAvatarURL(),
+      ],
+      description: `<@${msg.author.id}>, you have no nfts.`,
+    })
+    return { embeds: [embed], components: [selectOtherViewComponent()] }
+  }
+
+  const currentSelectedCollection =
+    userNftCollections.find(
+      (collection) => collection.collection_address === collectionAddress
+    ) ?? userNftCollections[0]
+
+  const { name: colName, image: colImage } = currentSelectedCollection
+  const pageSize = 1
+
+  const { total: userNftsTotal, data: userNfts } = await profile.getUserNFT({
+    userAddress,
+    collectionAddress: currentSelectedCollection.collection_address,
+    page: page,
+    size: pageSize,
+  })
+  const totalPage = Math.ceil(userNftsTotal / pageSize)
+
+  if (userNfts.length === 0) {
+    const embed = composeEmbedMessage(msg, {
+      author: [
+        `${msg.author.username}'s NFT collection`,
+        msg.author.displayAvatarURL(),
+      ],
+      description: `<@${msg.author.id}>, you have no nfts.`,
+    })
+    return { embeds: [embed], components: [selectOtherViewComponent()] }
+  }
+
+  const icons = await profile.getNFTMetadataAttrIcon()
+
+  const userNft = userNfts[0]
+  const nftDetail = await profile.getNFTDetails({
+    collectionAddress: userNft.collection_address,
+    tokenId: userNft.token_id,
+  })
+  const { name, attributes, rarity, image, collection_address, token_id } =
+    nftDetail
+
+  const nftImage = isValidHttpUrl(image) ? image : null
+  // set rank, rarity score empty if have data
+  const rarityRate = rarity?.rarity
+    ? `**${DOT}** ${getRarityEmoji(rarity.rarity)}`
+    : ""
+  let description = `**[${
+    name ?? ""
+  }](https://getmochi.co/nfts/${collection_address}/${token_id})**`
+  description += rarity?.rank
+    ? `\n\n🏆** ・ Rank: ${rarity.rank} ** ${rarityRate}`
+    : ""
+
+  const attributesFiltered = attributes.filter(
+    (obj: { trait_type: string }) => {
+      return obj.trait_type !== ""
+    }
+  )
+
+  const fields: EmbedFieldData[] = attributesFiltered
+    ? attributesFiltered.map((attr) => {
+        const val = `${attr.value}\n${attr.frequency ?? ""}`
+        return {
+          name: `${getIcon(icons, attr.trait_type)} ${attr.trait_type}`,
+          value: `${val ? val : "-"}`,
+          inline: true,
+        }
+      })
+    : []
+  let embed = composeEmbedMessage(msg, {
+    author: [
+      capitalizeFirst(`${colName} (${page + 1}/${totalPage})`),
+      ...(colImage.length ? [colImage] : []),
+    ],
+    description,
+    image: nftImage,
+    color: rarityColors[rarity?.rarity?.toUpperCase()],
+  }).addFields(fields)
+  embed = justifyEmbedFields(embed, 3)
+
+  return {
+    embeds: [embed],
+    components: [
+      ...getPaginationRow(page, totalPage),
+      selectCollectionComponent(
+        userNftCollections.map((collection) => ({
+          name: collection.name,
+          collectionAddress: collection.collection_address,
+          default:
+            collection.collection_address ===
+            currentSelectedCollection.collection_address,
+        }))
+      ),
+      selectOtherViewComponent("nft"),
+    ],
+  }
+}
+
+async function getCurrentViewEmbed(params: {
+  msg: Message
+  currentView: string
+  value?: string
+  page?: number
+}): Promise<MessageOptions> {
+  const { msg, currentView, value, page } = params
+  try {
+    if (currentView == "nft") {
+      return await composeMyNFTEmbed(msg, value, page)
+    } else {
+      return await composeMyProfileEmbed(msg)
+    }
+  } catch {
+    return {
+      embeds: [getErrorEmbed({ msg })],
+      components: [selectOtherViewComponent()],
+    }
+  }
 }
 
 const command: Command = {
@@ -435,11 +346,55 @@ const command: Command = {
   brief: "Check your server profile",
   category: "Profile",
   run: async (msg) => {
-    const data = await profile.getUserProfile(msg.guildId, msg.author.id)
-    return {
-      messageOptions: {
-        files: [await renderProfile(msg, data)],
+    let currentView = "profile"
+    let currentCollection = ""
+
+    const messageOptions = await getCurrentViewEmbed({ msg, currentView })
+    const reply = await msg.reply(messageOptions)
+
+    reply
+      .createMessageComponentCollector({
+        componentType: MessageComponentTypes.SELECT_MENU,
+        idle: 60000,
+      })
+      .on("collect", async (i) => {
+        await i.deferUpdate()
+        if (i.customId === "selectView") {
+          currentView = i.values[0]
+        } else if (i.customId == "selectCollection") {
+          currentCollection = i.values[0]
+        }
+
+        const messageOptions = await getCurrentViewEmbed({
+          msg,
+          currentView,
+          value: i.values[0],
+        })
+        await i.editReply(messageOptions)
+      })
+      .on("end", async () => {
+        await reply.edit({ components: [] })
+      })
+
+    listenForPaginateAction(
+      reply,
+      msg,
+      async (msg, page) => {
+        return {
+          messageOptions: await getCurrentViewEmbed({
+            msg,
+            currentView,
+            value: currentCollection,
+            page,
+          }),
+        }
       },
+      false,
+      true
+    )
+
+    return {
+      messageOptions: null,
     }
   },
   getHelpMessage: async (msg) => {

--- a/src/env.ts
+++ b/src/env.ts
@@ -14,6 +14,9 @@ export const API_SERVER_HOST =
 export const PT_API_SERVER_HOST =
   process.env.PT_API_SERVER_HOST || "https://backend.pod.so"
 
+export const INDEXER_API_SERVER_HOST =
+  process.env.INDEXER_API_SERVER_HOST || "https://api.indexer.console.so"
+
 export const LOG_CHANNEL_ID = process.env.LOG_CHANNEL_ID || "932579148608729118"
 export const ALERT_CHANNEL_ID =
   process.env.ALERT_CHANNEL_ID || "1003709369973735535"

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -76,3 +76,76 @@ export type UserWallet = {
   address: string
   chain_type: string
 }
+
+export type GetUserNFTResponse = {
+  page: number
+  size: number
+  sort: string
+  total: number
+  data: UserNFT[]
+}
+
+export type UserNFT = {
+  token_id: string
+  collection_address: string
+  name: string | null
+  description: string | null
+  amount: string | null
+  image: string
+  image_cdn: string | null
+  thumbnail_cdn: string | null
+  rarity_rank: number | null
+  rarity_score: string | null
+  rarity_tier: string | null
+  is_self_hosted: boolean
+  attributes: UserNFTAttribute[] | null
+  rarity: UserNFTRarity | null
+}
+
+type UserNFTAttribute = {
+  trait_type: string
+  value: string
+  count: number
+  rarity: string
+  frequency: string
+}
+
+type UserNFTRarity = {
+  rank: number
+  score: string
+  total: number
+  rarity: string
+}
+
+export type GetUserNFTCollectionResponse = {
+  page: number
+  size: number
+  sort: string
+  total: number
+  data: UserNFTCollection[]
+}
+
+export type UserNFTCollection = {
+  id: number
+  collection_address: string
+  name: string
+  symbol: string
+  chain_id: number
+  erc_format: string | null
+  supply: number
+  is_rariry_calculated: boolean
+  image: string
+  description: string
+  contract_scan: string
+  discord: string
+  twitter: string
+  website: string
+  owners: number
+}
+
+export type NFTMetadataAttrIcon = {
+  id: number
+  trait_type: string
+  discord_icon: string
+  unicode_icon: string
+}

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -60,7 +60,7 @@ export const tokenEmojis: Record<string, string> = {
   XMR: "1005008819866312724",
   BCH: "1005008800106942525",
   APE: "1005008782486675536",
-  DFG: "1005008750916161637",
+  DFG: "1007157463256145970",
   ICY: ":ice_cube:",
   CARROT: ":carrot:",
   BUTT: "1007247521468403744",
@@ -77,6 +77,20 @@ export const numberEmojis: Record<string, string> = {
   NUM_7: "932856132958048276",
   NUM_8: "932856132869976136",
   NUM_9: "932856132832223232",
+}
+
+export const progressBarEmojis: Record<string, string> = {
+  BAR_1_EMPTY: "1004837203735756881",
+  BAR_1_HALF: "1004837199851835392",
+  BAR_1_MID: "1004837201630199989",
+  BAR_1_FULL: "1004827891659452438",
+  BAR_2_EMPTY: "1004837205937770658",
+  BAR_2_MID: "1004837197372997782",
+  BAR_2_HIGH: "1004837692984537258",
+  BAR_2_FULL: "1004837191660343336",
+  BAR_3_EMPTY: "1004837207850356847",
+  BAR_3_MID: "1004837195510722630",
+  BAR_3_FULL: "1004837193673613412",
 }
 
 export const defaultEmojis: Record<string, string> = {
@@ -120,6 +134,7 @@ export const emojis: { [key: string]: string } = {
   ...rarityEmojis,
   ...marketplaceEmojis,
   ...traitEmojis,
+  ...progressBarEmojis,
 }
 
 export const tripodEmojis: Record<string, string> = {
@@ -350,4 +365,14 @@ export function getMarketplaceNftUrl(
   tokenId: string
 ) {
   return `${MARKETPLACE_BASE_URL}/asset/${collectionAddress}/${tokenId}`
+}
+
+export function isValidHttpUrl(urlStr: string) {
+  let url
+  try {
+    url = new URL(urlStr)
+  } catch (_) {
+    return false
+  }
+  return url.protocol === "http:" || url.protocol === "https:"
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,8 @@
-import { API_SERVER_HOST, PT_API_SERVER_HOST } from "env"
+import {
+  API_SERVER_HOST,
+  PT_API_SERVER_HOST,
+  INDEXER_API_SERVER_HOST,
+} from "env"
 
 export const DOT = "•"
 export const COMMA = ","
@@ -18,6 +22,7 @@ export const DEFI_DEFAULT_FOOTER = `Use ${PREFIX}tokens for a list of supported 
 
 export const API_BASE_URL = `${API_SERVER_HOST}/api/v1`
 export const PT_API_BASE_URL = `${PT_API_SERVER_HOST}/api/v1`
+export const INDEXER_API_BASE_URL = `${INDEXER_API_SERVER_HOST}/api/v1`
 
 export const VALID_BOOST_MESSAGE_TYPES = [
   "USER_PREMIUM_GUILD_SUBSCRIPTION",

--- a/src/utils/discordEmbed.ts
+++ b/src/utils/discordEmbed.ts
@@ -391,7 +391,8 @@ export function listenForPaginateAction(
     msg: Message,
     pageIdx: number
   ) => Promise<{ messageOptions: MessageOptions }>,
-  withAttachmentUpdate?: boolean
+  withAttachmentUpdate?: boolean,
+  withMultipleComponents?: boolean
 ) {
   const operators: Record<string, number> = {
     "+": 1,
@@ -407,20 +408,23 @@ export function listenForPaginateAction(
       const [pageStr, opStr, totalPage] = i.customId.split("_").slice(1)
       const page = +pageStr + operators[opStr]
       const {
-        messageOptions: { embeds, files },
+        messageOptions: { embeds, components, files },
       } = await render(originalMsg, page)
 
+      const msgComponents = withMultipleComponents
+        ? components
+        : getPaginationRow(page, +totalPage)
       if (withAttachmentUpdate && files?.length) {
         await replyMsg.removeAttachments()
         await replyMsg.edit({
           embeds,
-          components: getPaginationRow(page, +totalPage),
+          components: msgComponents,
           files,
         })
       } else {
         await replyMsg.edit({
           embeds,
-          components: getPaginationRow(page, +totalPage),
+          components: msgComponents,
         })
       }
     })


### PR DESCRIPTION
**What does this PR do?**

-   [x] Update My Profile view from canvas to textbase
-   [x] Add NFT collections view to $profile command

**How to test**

- Use the command `$profile` to check the new profile view
- Select My NFT from Selection Menu to view the user's NFT collections

**Media (Loom or gif)**
<img width="550" alt="CleanShot 2022-08-19 at 09 38 25@2x" src="https://user-images.githubusercontent.com/14150687/185530952-dd0f7b34-6527-457e-8258-d070d5a388a7.png">
<img width="515" alt="CleanShot 2022-08-19 at 09 38 48@2x" src="https://user-images.githubusercontent.com/14150687/185530999-ebb5bd75-507b-48bb-948a-f467c9bc7302.png">

