### PR TITLE
fix: add select menu to choose other collection after nft query

### DIFF
--- a/src/commands/community/nft/query.ts
+++ b/src/commands/community/nft/query.ts
@@ -30,6 +30,7 @@ import {
 import { NFTMetadataAttrIcon } from "types/community"
 import config from "adapters/config"
 import { MessageComponentTypes } from "discord.js/typings/enums"
+import { NFTSymbol } from "types/config"
 
 const rarityColors: Record<string, string> = {
   COMMON: "#939393",
@@ -152,6 +153,28 @@ export async function setDefaultSymbol(i: ButtonInteraction) {
   })
 }
 
+function addSuggestionIfAny(
+  symbol: string,
+  tokenId: string,
+  _suggestions?: Array<NFTSymbol>
+) {
+  const suggestions = _suggestions ?? []
+  const duplicatedSymbols =
+    suggestions.reduce((acc, s) => acc.add(s.symbol), new Set()).size === 1
+  const components = getSuggestionComponents(
+    suggestions.map((s, i) => ({
+      label: s.name,
+      value: `${s.address}/${tokenId}/${symbol}/${s.chain}/${duplicatedSymbols}`,
+      emoji:
+        i > 8
+          ? `${getEmoji(`NUM_${Math.floor(i / 9)}`)}${getEmoji(`NUM_${i % 9}`)}`
+          : getEmoji(`NUM_${i + 1}`),
+    }))
+  )
+
+  return components ? { components: [components] } : {}
+}
+
 const command: Command = {
   id: "nft_query",
   command: "query",
@@ -195,6 +218,7 @@ const command: Command = {
             collectionDetailRes.data.image
           ),
         ],
+        ...addSuggestionIfAny(symbol, tokenId),
       })
     } else {
       // ambiguity, check if there is default_symbol first
@@ -202,6 +226,11 @@ const command: Command = {
         // there is, so we use its collection address to get
         const collectionDetailRes = await community.getNFTCollectionDetail(
           res.default_symbol.address
+        )
+        const components = addSuggestionIfAny(
+          res.default_symbol.symbol,
+          tokenId,
+          res.suggestions
         )
         res = await community.getNFTDetail(
           res.default_symbol.address,
@@ -217,24 +246,10 @@ const command: Command = {
               collectionDetailRes.data.image
             ),
           ],
+          ...components,
         })
       } else {
         // there isn't, so we continue to check for the `suggestions` property
-        const duplicatedSymbols =
-          res.suggestions?.reduce((acc, s) => acc.add(s.symbol), new Set())
-            .size === 1
-        const components = getSuggestionComponents(
-          res.suggestions.map((s, i) => ({
-            label: s.name,
-            value: `${s.address}/${tokenId}/${symbol}/${s.chain}/${duplicatedSymbols}`,
-            emoji:
-              i > 8
-                ? `${getEmoji(`NUM_${Math.floor(i / 9)}`)}${getEmoji(
-                    `NUM_${i % 9}`
-                  )}`
-                : getEmoji(`NUM_${i + 1}`),
-          }))
-        )
         const embed = getSuggestionEmbed({
           title: `Multiple results for ${symbol}`,
           msg,
@@ -250,7 +265,7 @@ const command: Command = {
 
         replyMsg = await msg.reply({
           embeds: [embed],
-          ...(components ? { components: [components] } : {}),
+          ...addSuggestionIfAny(symbol, tokenId, res.suggestions),
         })
       }
     }
@@ -262,7 +277,8 @@ const command: Command = {
       const detailRes = await community.getNFTCollectionDetail(colAddress)
 
       if (!res.ok || !detailRes.ok || !res.data || !detailRes.data) {
-        await msg.reply({
+        await i.deferUpdate()
+        await replyMsg.edit({
           embeds: [
             getErrorEmbed({
               msg,
@@ -279,7 +295,7 @@ const command: Command = {
               detailRes.data.image
             ),
           ],
-          components: [],
+          ...addSuggestionIfAny(symbol, tokenId, res.suggestions),
         })
         if (
           hasAdministrator(msg.member) &&


### PR DESCRIPTION
**What does this PR do?**

-   [x] Add select menu to choose other collections after nft query (has default symbol)

Same flow

**Media (Loom or gif)**
![image](https://user-images.githubusercontent.com/25856620/186062844-a2e89ade-ebf5-4b9f-bbb2-2860c6201fc3.png)

