### PR TITLE
fix: capitalize trait value when render nft embed

### DIFF
--- a/src/commands/community/nft/query.ts
+++ b/src/commands/community/nft/query.ts
@@ -20,6 +20,7 @@ import {
 } from "utils/discordEmbed"
 import community from "adapters/community"
 import {
+  capFirst,
   capitalizeFirst,
   getEmoji,
   getMarketplaceCollectionUrl,
@@ -98,9 +99,11 @@ async function composeNFTDetail(
 
     const fields: EmbedFieldData[] = attributesFiltered
       ? attributesFiltered.map((attr: any) => {
-          const val = `${attr.value}\n${attr.frequency ?? ""}`
+          const val = `${capFirst(attr.value)}\n${attr.frequency ?? ""}`
           return {
-            name: `${getIcon(icons, attr.trait_type)} ${attr.trait_type}`,
+            name: `${getIcon(icons, attr.trait_type)} ${capFirst(
+              attr.trait_type
+            )}`,
             value: `${val ? val : "-"}`,
             inline: true,
           }


### PR DESCRIPTION
**What does this PR do?**

-   [x] Capitalize trait value when rendering nft embed

**Media (Loom or gif)**
![image](https://user-images.githubusercontent.com/25856620/186119094-e4b0b51a-c243-41ce-a785-0b6f235945ef.png)

