### PR TITLE
fix: rework default role command

### DIFF
--- a/src/adapters/config.ts
+++ b/src/adapters/config.ts
@@ -243,55 +243,23 @@ class Config extends Fetcher {
   }
 
   public async getCurrentDefaultRole(guildId: string) {
-    const res = await fetch(
+    return this.jsonFetch(
       `${API_BASE_URL}/configs/default-roles?guild_id=${guildId}`
     )
-    if (res.status !== 200) {
-      logger.error(`failed to get current default role - guild ${guildId}`)
-      return null
-    } else {
-      const json = await res.json()
-      if (json.error !== undefined) {
-        throw new Error(json.error)
-      }
-      return json
-    }
   }
 
   public async configureDefaultRole(event: DefaultRoleEvent) {
-    const res = await fetch(`${API_BASE_URL}/configs/default-roles`, {
+    return this.jsonFetch(`${API_BASE_URL}/configs/default-roles`, {
       method: "POST",
       body: JSON.stringify(event),
     })
-    if (res.status !== 200) {
-      throw new Error(
-        `failed to configure default role - guild ${event.guild_id}`
-      )
-    }
-
-    const json = await res.json()
-    if (json.error !== undefined) {
-      throw new Error(json.error)
-    }
-    return json
   }
 
   public async removeDefaultRoleConfig(guildId: string) {
-    const res = await fetch(
+    return this.jsonFetch(
       `${API_BASE_URL}/configs/default-roles?guild_id=${guildId}`,
-      {
-        method: "DELETE",
-      }
+      { method: "DELETE" }
     )
-    if (res.status !== 200) {
-      throw new Error(`failed to remove default role config - guild ${guildId}`)
-    }
-
-    const json = await res.json()
-    if (json.error !== undefined) {
-      throw new Error(json.error)
-    }
-    return json
   }
 
   public async listAllReactionRoles(guildId: string) {

--- a/src/adapters/fetcher.ts
+++ b/src/adapters/fetcher.ts
@@ -2,6 +2,7 @@ import deepmerge from "deepmerge"
 import { logger } from "logger"
 import type { RequestInit as NativeRequestInit } from "node-fetch"
 import fetch from "node-fetch"
+import { capFirst } from "utils/common"
 
 type RequestInit = NativeRequestInit & {
   /**
@@ -54,11 +55,11 @@ export class Fetcher {
         )
 
         const json = await (res as ErrResponse).json()
-        if (autoWrap500Error) {
+        if (autoWrap500Error && res.status === 500) {
           json.error =
             "Something went wrong, our team is notified and is working on the fix, stay tuned."
         } else {
-          json.error = `${json.error[0].toUpperCase}${json.error.slice(1)}`
+          json.error = capFirst(json.error)
         }
         json.ok = false
         return json

--- a/src/commands/config/defaultRole/index.ts
+++ b/src/commands/config/defaultRole/index.ts
@@ -22,6 +22,8 @@ const command: Command = {
     embeds: [
       composeEmbedMessage(msg, {
         usage: `${PREFIX}dr <action>`,
+        description:
+          "Set a default role that will automatically assigned to newcomers when they first join your server",
         footer: [`Type ${PREFIX}help dr <action> for a specific action!`],
         includeCommandsList: true,
       }),
@@ -30,6 +32,7 @@ const command: Command = {
   aliases: ["dr"],
   actions,
   colorType: "Server",
+  canRunWithoutAction: false,
 }
 
 export default command

--- a/src/commands/config/defaultRole/remove.ts
+++ b/src/commands/config/defaultRole/remove.ts
@@ -1,11 +1,13 @@
 import { Command } from "types/common"
 import { PREFIX } from "utils/constants"
-import { composeEmbedMessage } from "utils/discordEmbed"
+import {
+  composeEmbedMessage,
+  getErrorEmbed,
+  getSuccessEmbed,
+} from "utils/discordEmbed"
 import { Message } from "discord.js"
 import config from "adapters/config"
 import { getCommandArguments } from "utils/commands"
-import ChannelLogger from "utils/ChannelLogger"
-import { BotBaseError } from "errors"
 
 const command: Command = {
   id: "defaultrole_remove",
@@ -30,24 +32,21 @@ const command: Command = {
       }
     }
 
-    try {
-      const res = await config.removeDefaultRoleConfig(msg.guild.id)
-      if (res.success) {
-        description = "Successfully removed default role for newcomers."
+    const res = await config.removeDefaultRoleConfig(msg.guild.id)
+    if (res.ok) {
+      description =
+        "Existing users' role will not be affected\nHowever please **NOTE** that from now on new users joining your server won't have a default role anymore.\nTo set a new one, run `$dr set @<role_name>`"
+    } else {
+      return {
+        messageOptions: {
+          embeds: [getErrorEmbed({ msg, description: res.error })],
+        },
       }
-    } catch (error) {
-      ChannelLogger.log(error as BotBaseError)
-      description = "Failed to remove default role configuration."
     }
 
     return {
       messageOptions: {
-        embeds: [
-          composeEmbedMessage(msg, {
-            title: "Default Role",
-            description,
-          }),
-        ],
+        embeds: [getSuccessEmbed({ msg, title: "Role removed", description })],
       },
     }
   },

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -15,7 +15,7 @@ import ticker from "./defi/ticker"
 import airdrop from "./defi/airdrop"
 import gm from "./community/gm"
 // import whitelist from "./community/campaigns"
-// import defaultrole from "./config/defaultRole"
+import defaultrole from "./config/defaultRole"
 import reactionrole from "./config/reactionRole"
 // import starboard from "./config/starboard"
 import top from "./community/top"
@@ -55,9 +55,9 @@ import { HELP } from "utils/constants"
 export const originalCommands: Record<string, Command> = {
   // general help
   help,
-  // profile
+  // profile section
   profile,
-  // defi
+  // defi section
   deposit,
   tip,
   balances,
@@ -65,7 +65,7 @@ export const originalCommands: Record<string, Command> = {
   tokens,
   ticker,
   airdrop,
-  // community
+  // community section
   invite,
   gm,
   stats,
@@ -73,9 +73,10 @@ export const originalCommands: Record<string, Command> = {
   gift,
   top,
   sales,
-  // config
+  verify,
+  // config section
   reactionrole,
-  // defaultrole,
+  defaultrole,
   // whitelist,
   levelrole,
   nftrole,
@@ -84,8 +85,8 @@ export const originalCommands: Record<string, Command> = {
   // eventxp,
   // log,
   poe,
+  // games section
   tripod,
-  verify,
 }
 export const commands = getAllAliases(originalCommands)
 

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -1,7 +1,15 @@
 import { Message } from "discord.js"
 
 import { Command } from "types/common"
-import { HELP, PREFIX, SPACES_REGEX } from "./constants"
+import {
+  CHANNEL_PREFIX,
+  EMOJI_PREFIX,
+  HELP,
+  PREFIX,
+  ROLE_PREFIX,
+  SPACES_REGEX,
+  USER_PREFIX,
+} from "./constants"
 import { commands } from "commands"
 
 export const getCommandArguments = (message: Message) => {
@@ -89,6 +97,18 @@ export const getCommandMetadata = (msg: Message) => {
   const cmdObj = commands[commandKey]
   if (!Object.keys(cmdObj?.actions ?? []).includes(action)) action = undefined
   return { commandKey, action }
+}
+
+export function parseDiscordToken(value: string) {
+  const _value = value.trim()
+  return {
+    isEmoji: _value.startsWith(EMOJI_PREFIX) && _value.endsWith(">"),
+    isUser: _value.startsWith(USER_PREFIX) && _value.endsWith(">"),
+    isRole: _value.startsWith(ROLE_PREFIX) && _value.endsWith(">"),
+    isChannel: _value.startsWith(CHANNEL_PREFIX) && _value.endsWith(">"),
+    isId: /\d+/g.test(_value),
+    id: _value.replace(/\D/g, ""),
+  }
 }
 
 // export const normalizeMessage = (msg: Message) => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -32,3 +32,7 @@ export const VALID_BOOST_MESSAGE_TYPES = [
 ]
 
 export const HOMEPAGE_URL = "http://getmochi.co"
+export const ROLE_PREFIX = "<@&"
+export const CHANNEL_PREFIX = "<#"
+export const USER_PREFIX = "<@"
+export const EMOJI_PREFIX = "<:"


### PR DESCRIPTION
**What does this PR do?**

-   [x] Enable and rework default role command
-   [x] Add a small feature in default role set command (support role id)
-   [x] Add a helper for parsing discord arg (`parseDiscordToken`) 
-   [x] Small tweak to the `jsonFetch` method

**How to test**

-   `$dr`
-   `$dr info`
-   `$dr set`
-   `$dr remove`

**Edge cases**

-   User passing in something that is not a role or role id (handled), image below

**Media (Loom or gif)**
<img width="563" alt="Xnapper-2022-08-23-18 00 25" src="https://user-images.githubusercontent.com/25856620/186144365-59607401-a028-4fcd-952b-785a02e0d9fe.png">
<img width="564" alt="Xnapper-2022-08-23-18 00 44" src="https://user-images.githubusercontent.com/25856620/186144385-b3002337-dcd9-468c-8139-bf4305a12995.png">

Handle invalid case
<img width="561" alt="Xnapper-2022-08-23-18 05 06" src="https://user-images.githubusercontent.com/25856620/186144395-a38b0f1a-2c59-456f-be99-41d7c10f830a.png">

|Before|After|
|---|---|
|<img width="434" alt="Xnapper-2022-08-23-18 09 34" src="https://user-images.githubusercontent.com/25856620/186144401-408c6160-e7d8-475d-ab25-eda6ba6cfb5a.png">|<img width="434" alt="Xnapper-2022-08-23-18 04 56" src="https://user-images.githubusercontent.com/25856620/186144391-aa43bb87-6842-4440-9c92-c6868c1b626e.png">|

|Before|After|
|---|---|
|<img width="357" alt="Xnapper-2022-08-23-18 09 56" src="https://user-images.githubusercontent.com/25856620/186144407-fed81f9e-0453-4642-972d-2eb162d8a606.png">|<img width="559" alt="Xnapper-2022-08-23-18 06 28" src="https://user-images.githubusercontent.com/25856620/186144397-48473086-2265-4980-bff4-0c96c555747c.png">|