### PR TITLE
fix: from_twitter not adding to config

### DIFF
--- a/src/commands/config/poe/twitter/list.ts
+++ b/src/commands/config/poe/twitter/list.ts
@@ -13,7 +13,7 @@ export function getMessageBody({
   user_id,
   channel_id,
   updated_at,
-  from_username = [],
+  from_twitter = [],
   twitter_username = [],
 }: {
   user_id: string
@@ -21,19 +21,21 @@ export function getMessageBody({
   channel_id: string
   hashtag?: string[]
   twitter_username?: string[]
-  from_username?: string[]
+  from_twitter?: string[]
 }) {
   return `Set by: <@${user_id}>${
     updated_at
       ? ` (${dayjs(updated_at).utc().format("MMM DD YYYY HH:mm:ss UTC")})`
       : ""
   }\nCheck updates in <#${channel_id}>\nTags: ${hashtag
+    .filter(Boolean)
     .map((t: string) => `\`${t}\``)
     .join(", ")}\nMentions: ${twitter_username
+    .filter(Boolean)
     .map((t: string) => `\`${t}\``)
-    .join(", ")}\nTweets from: ${from_username.map(
-    (t: string) => `\`@${t.slice(fromPrefix.length)}\``
-  )}`
+    .join(", ")}\nTweets from: ${from_twitter
+    .filter(Boolean)
+    .map((t: string) => `\`@${t.slice(fromPrefix.length)}\``)}`
 }
 
 const command: Command = {
@@ -73,7 +75,7 @@ const command: Command = {
               channel_id: twitterConfig.data.channel_id,
               hashtag: twitterConfig.data.hashtag,
               twitter_username: twitterConfig.data.twitter_username,
-              from_username: twitterConfig.data.from_username,
+              from_twitter: twitterConfig.data.from_twitter,
             }),
           }),
         ],

--- a/src/commands/config/poe/twitter/set.ts
+++ b/src/commands/config/poe/twitter/set.ts
@@ -157,7 +157,7 @@ const command: Command = {
               twitter_username: triggerKeywords.filter((k) =>
                 k.startsWith(handlePrefix)
               ),
-              from_username: triggerKeywords.filter((k) =>
+              from_twitter: triggerKeywords.filter((k) =>
                 k.startsWith(fromPrefix)
               ),
             }),

--- a/src/utils/TwitterStream.ts
+++ b/src/utils/TwitterStream.ts
@@ -185,7 +185,11 @@ class TwitterStream extends InmemoryStorage {
             twitter_username: Array<string>
           }) => {
             const newRuleId = await this.upsertRule({
-              ruleValue: [...config.hashtag, ...config.twitter_username],
+              ruleValue: [
+                ...config.hashtag,
+                ...config.twitter_username,
+                ...config.from_twitter,
+              ],
               guildId: config.guild_id,
               channelId: config.channel_id,
               ruleId: config.rule_id,


### PR DESCRIPTION
**What does this PR do?**

-   [x] Rename `from_username` to `from_twitter` to match api response
-   [x] Add `from_twitter` value when running `up` when starting bot
-   [x] Add filter to remove empty string value when showing format message
