### PR TITLE
fix: scope gm/gn command to admin

### DIFF
--- a/src/commands/community/gm/config.ts
+++ b/src/commands/community/gm/config.ts
@@ -62,6 +62,7 @@ const command: Command = {
   aliases: ["cfg"],
   colorType: "Command",
   minArguments: 3,
+  onlyAdministrator: true,
 }
 
 export default command

--- a/src/commands/community/gm/info.ts
+++ b/src/commands/community/gm/info.ts
@@ -58,6 +58,7 @@ const command: Command = {
   },
   canRunWithoutAction: true,
   colorType: "Command",
+  onlyAdministrator: true,
 }
 
 export default command


### PR DESCRIPTION
**What does this PR do?**

-   [x] Restrict gm command to admin only
