### PR TITLE
fix: refuse handling empty message

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -40,7 +40,8 @@ export default {
   name: "messageCreate",
   once: false,
   execute: async (message: Message) => {
-    if (message.author.bot) return
+    // deny handling if author is bot or message is empty (new user join server)
+    if (message.author.bot || !message.content) return
 
     try {
       if (message.content.startsWith(PREFIX)) {


### PR DESCRIPTION
**What does this PR do?**
-   [x] Refuse to handling empty message (triggered when a user join guild)