### PR TITLE
fix: sale tracker show collection and chain name

### DIFF
--- a/src/commands/community/sales/list.ts
+++ b/src/commands/community/sales/list.ts
@@ -6,7 +6,7 @@ import {
   composeSimpleSelection,
 } from "utils/discordEmbed"
 import community from "adapters/community"
-import { shortenHashOrAddress } from "utils/common"
+import { capFirst, shortenHashOrAddress } from "utils/common"
 
 const command: Command = {
   id: "sales_list",
@@ -63,9 +63,9 @@ const command: Command = {
             }>:\n${composeSimpleSelection(
               res.data.collection.map(
                 (c: any) =>
-                  `\`${shortenHashOrAddress(
+                  `\`${capFirst(c.name)} (${shortenHashOrAddress(
                     c.contract_address
-                  )}\` - platform id ${c.platform}`
+                  )}) ${c.chain.name}\``
               )
             )}`,
           }),


### PR DESCRIPTION
**What does this PR do?**

-   [x] Show collection name, chain name

**How to test**
`$sale list`

**Media (Loom or gif)**
|Before|After|
|---|---|
|<img width="402" alt="Xnapper-2022-08-31-17 22 30" src="https://user-images.githubusercontent.com/25856620/187658059-80ab7e7e-19ac-448b-aac2-cb11b427a95e.png">|<img width="444" alt="Xnapper-2022-08-31-17 22 20" src="https://user-images.githubusercontent.com/25856620/187658046-430c789c-6de7-4be5-a5e1-6a37f917cb98.png">

