### PR TITLE
feat: slash commands migration

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -3,6 +3,9 @@ NODE_ENV='development'
 # Your Discord Bot token
 DISCORD_TOKEN='...'
 
+# Your Discord Application ID
+APPLICATION_ID='...'
+
 # A log channel id in your dev server
 LOG_CHANNEL_ID='...'
 

--- a/src/commands/defi/ticker_slash.ts
+++ b/src/commands/defi/ticker_slash.ts
@@ -16,6 +16,7 @@ import {
   getEmoji,
   hasAdministrator,
   roundFloatNumber,
+  thumbnails,
 } from "utils/common"
 import {
   composeDiscordSelectionRow,
@@ -24,6 +25,7 @@ import {
   composeDaysSelectMenu,
   getSuccessEmbed,
   composeDiscordExitButton,
+  composeEmbedMessage2,
 } from "utils/discordEmbed"
 import Defi from "adapters/defi"
 import {
@@ -35,6 +37,7 @@ import config from "adapters/config"
 import { Coin } from "types/defi"
 import { SlashCommandBuilder } from "@discordjs/builders"
 import Compare from "./token/compare_slash"
+import { PREFIX } from "utils/constants"
 
 async function renderHistoricalMarketChart({
   coinId,
@@ -335,27 +338,27 @@ async function composeTickerSelectionResponse(
   }
 }
 
-const data = new SlashCommandBuilder()
-  .setName("ticker")
-  .setDescription("Show/Compare coins price and market cap")
-  .addStringOption((option) =>
-    option
-      .setName("base")
-      .setDescription("the cryptocurrency which you wanna check price.")
-      .setRequired(true)
-  )
-  .addStringOption((option) =>
-    option
-      .setName("target")
-      .setDescription("the second cryptocurrency for comparison.")
-      .setRequired(false)
-  )
-
 const command: SlashCommand = {
-  command: "ticker",
-  data,
+  name: "ticker",
+  category: "Defi",
+  prepare: () => {
+    return new SlashCommandBuilder()
+      .setName("ticker")
+      .setDescription("Show/Compare coins price and market cap")
+      .addStringOption((option) =>
+        option
+          .setName("base")
+          .setDescription("the cryptocurrency which you wanna check price.")
+          .setRequired(true)
+      )
+      .addStringOption((option) =>
+        option
+          .setName("target")
+          .setDescription("the second cryptocurrency for comparison.")
+          .setRequired(false)
+      )
+  },
   run: async function (interaction: CommandInteraction) {
-    await interaction.deferReply()
     const baseQ = interaction.options.getString("base")
     if (!interaction.guildId || !baseQ) return null
     // run token comparison
@@ -392,6 +395,18 @@ const command: SlashCommand = {
       interaction
     )
   },
+  help: async (interaction) => ({
+    embeds: [
+      composeEmbedMessage2(interaction, {
+        thumbnail: thumbnails.TOKENS,
+        title: "Display/Compare coin price and market cap",
+        description: `Data is fetched from [CoinGecko](https://coingecko.com/)`,
+        usage: `${PREFIX}ticker <symbol>\n${PREFIX}ticker <base>/<target> (comparison)`,
+        examples: `${PREFIX}ticker eth\n${PREFIX}ticker fantom\n${PREFIX}ticker btc/bnb`,
+      }),
+    ],
+  }),
+  colorType: "Defi",
 }
 
 export default command

--- a/src/commands/help_slash.ts
+++ b/src/commands/help_slash.ts
@@ -1,0 +1,117 @@
+import { CommandInteraction } from "discord.js"
+import { HELP_CMD, HOMEPAGE_URL } from "utils/constants"
+import dayjs from "dayjs"
+import utc from "dayjs/plugin/utc"
+import { slashCommands } from "../index"
+import { emojis, thumbnails } from "utils/common"
+import config from "../adapters/config"
+import { Category, SlashCommand } from "types/common"
+import {
+  composeEmbedMessage2,
+  EMPTY_FIELD,
+  justifyEmbedFields,
+} from "utils/discordEmbed"
+import { SlashCommandBuilder } from "@discordjs/builders"
+dayjs.extend(utc)
+
+const categoryIcons: Record<Category, string> = {
+  Profile: emojis.PROFILE,
+  Config: emojis.PROFILE,
+  Defi: emojis.DEFI,
+  Community: emojis.DEFI,
+  Game: emojis.GAME,
+}
+
+function getHelpEmbed(interaction: CommandInteraction) {
+  return composeEmbedMessage2(interaction, {
+    title: "Mochi's Help",
+    thumbnail: thumbnails.HELP,
+    // description: `Use \`${HELP_CMD} <command>\` for more details about a specific command`,
+    footer: [`Use ${HELP_CMD} <command> for details on a specific command`],
+  })
+}
+
+/**
+ * Validate if categories for admin can be displayed.
+ * Sort categories by number of their commands in DESCENDING order
+ *
+ */
+async function displayCategories() {
+  return Object.entries(categoryIcons).sort((catA, catB) => {
+    const commandsOfThisCatA: number = Object.values(slashCommands)
+      .filter(Boolean)
+      .filter((c) => c.category === catA[0]).length
+    const commandsOfThisCatB: number = Object.values(slashCommands)
+      .filter(Boolean)
+      .filter((c) => c.category === catB[0]).length
+
+    return commandsOfThisCatB - commandsOfThisCatA
+  })
+}
+
+const command: SlashCommand = {
+  name: "help",
+  category: "Profile",
+  prepare: (slashCommands) => {
+    const choices = Object.keys(slashCommands ?? {})
+      .filter((c) => c !== "help")
+      .map((c) => [`/${c}`, c]) as [string, string][]
+    return new SlashCommandBuilder()
+      .setName("help")
+      .setDescription("Help Menu")
+      .addStringOption((option) =>
+        option
+          .setName("command")
+          .setDescription("Command to provide details about.")
+          .setRequired(false)
+          .setChoices(choices)
+      )
+  },
+  run: async function (interaction: CommandInteraction) {
+    const command = interaction.options.getString("command")
+    const messageOptions = await (slashCommands[command ?? ""] ?? this).help(
+      interaction
+    )
+    return { messageOptions }
+  },
+  help: async (interaction: CommandInteraction) => {
+    const embed = getHelpEmbed(interaction)
+    const categories = await displayCategories()
+
+    let idx = 0
+    for (const item of Object.values(categories)) {
+      const category = item[0]
+      if (!(await config.slashCategoryIsScoped(interaction, category))) continue
+
+      const commandsByCat = (
+        await Promise.all(
+          Object.values(slashCommands)
+            .filter((cmd) => cmd.name !== "help")
+            .filter(
+              async (cmd) =>
+                await config.slashCommandIsScoped({
+                  interaction,
+                  category: cmd.category,
+                  command: cmd.name,
+                })
+            )
+        )
+      )
+        .filter((c) => c.category === category)
+        .map((c) => `[\`${c.name}\`](${HOMEPAGE_URL})`)
+        .join(" ")
+
+      if (!commandsByCat) continue
+
+      // add blank field as the third column
+      if (idx % 3 === 2) embed.addFields(EMPTY_FIELD)
+      embed.addField(`${category}`, `${commandsByCat}`, true)
+      idx++
+    }
+
+    return { embeds: [justifyEmbedFields(embed, 3)] }
+  },
+  colorType: "Command",
+}
+
+export default command

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -27,7 +27,10 @@ import nftrole from "./config/nftRole"
 import verify from "./community/verify"
 import log from "./config/log"
 import poe from "./config/poe"
-import ticker_slash from "./defi/ticker_slash"
+
+// slash commands
+// import help_slash from "./help_slash"
+// import ticker_slash from "./defi/ticker_slash"
 
 // external
 import { Message } from "discord.js"
@@ -47,15 +50,16 @@ import guildCustomCommand from "../adapters/guildCustomCommand"
 import { customCommandsExecute } from "./customCommand"
 import CommandChoiceManager from "utils/CommandChoiceManager"
 
-import { Command, Category, SlashCommand } from "types/common"
+import { Command, Category } from "types/common"
 import { hasAdministrator } from "utils/common"
 import ChannelLogger from "utils/ChannelLogger"
 import { getErrorEmbed } from "utils/discordEmbed"
 import { HELP } from "utils/constants"
 
-export const slashCommands: Record<string, SlashCommand> = {
-  ticker: ticker_slash,
-}
+// export const slashCommands: Record<string, SlashCommand> = {
+//   ticker: ticker_slash,
+//   help: help_slash,
+// }
 
 export const originalCommands: Record<string, Command> = {
   // general help

--- a/src/errors/CommandIsNotScopedError.ts
+++ b/src/errors/CommandIsNotScopedError.ts
@@ -1,6 +1,7 @@
-import { Message, TextChannel } from "discord.js"
+import { CommandInteraction, Message, TextChannel } from "discord.js"
 import { BotBaseError } from "./BaseError"
 
+// TODO: remove after slash command migration done
 export class CommandIsNotScopedError extends BotBaseError {
   constructor({
     message,
@@ -18,6 +19,28 @@ export class CommandIsNotScopedError extends BotBaseError {
       guild: message.guild?.name,
       channel: channel.name,
       user: message.author.tag,
+      data: { category, command },
+    })
+  }
+}
+
+export class SlashCommandIsNotScopedError extends BotBaseError {
+  constructor({
+    interaction,
+    category,
+    command,
+  }: {
+    interaction: CommandInteraction
+    category: string
+    command: string
+  }) {
+    super()
+    this.name = "Slash command is not scoped"
+    const channel = interaction.channel as TextChannel
+    this.message = JSON.stringify({
+      guild: interaction.guild?.id,
+      channel: channel.id,
+      user: interaction.user.id,
       data: { category, command },
     })
   }

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,4 +1,4 @@
-import { slashCommands } from "commands"
+import { slashCommands } from "index"
 import { confirmGlobalXP } from "commands/config/globalxp"
 import { confirmAirdrop, enterAirdrop } from "commands/defi/airdrop"
 import { backToTickerSelection } from "commands/defi/ticker"
@@ -53,7 +53,9 @@ export default {
 
 async function handleCommandInteraction(interaction: Interaction) {
   const i = interaction as CommandInteraction
-  const response = await slashCommands[i.commandName].run(i)
+  await i.deferReply()
+  const command = slashCommands[i.commandName]
+  const response = await command.run(i)
   if (!response) return
   const { messageOptions, commandChoiceOptions } = response
   const reply = await i.editReply(messageOptions)

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,16 @@ import { APPLICATION_ID, DISCORD_TOKEN } from "./env"
 import { REST } from "@discordjs/rest"
 import { Routes } from "discord-api-types/v9"
 import { logger } from "logger"
-import { slashCommands } from "commands"
+
+// slash commands
+import help_slash from "./commands/help_slash"
+import ticker_slash from "./commands/defi/ticker_slash"
+import { SlashCommand } from "types/common"
+
+export const slashCommands: Record<string, SlashCommand> = {
+  ticker: ticker_slash,
+  help: help_slash,
+}
 
 const client = new Discord.Client({
   intents: [
@@ -33,14 +42,14 @@ process.on("SIGTERM", () => {
 })
 
 // register slash commands
-const commands = Object.values(slashCommands).map((c) => c.data)
+const body = Object.values(slashCommands).map((c) => c.prepare(slashCommands))
 const rest = new REST({ version: "9" }).setToken(DISCORD_TOKEN)
 
 ;(async () => {
   try {
     logger.info("Started refreshing application (/) commands.")
     await rest.put(Routes.applicationCommands(APPLICATION_ID), {
-      body: commands,
+      body,
     })
     logger.info("Successfully reloaded application (/) commands.")
   } catch (error) {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -30,6 +30,36 @@ export const embedsColors: Record<string, string> = {
   Game: "#FFAD83",
 }
 
+export type SlashCommandChoiceOption = {
+  name: string
+  description: string
+  required: boolean
+  choices: [string, string][]
+}
+
+export type SlashCommand = {
+  name: string
+  category: Category
+  run: (interaction: CommandInteraction) => Promise<
+    | {
+        messageOptions: MessageOptions
+        commandChoiceOptions?: SetOptional<
+          CommandChoiceHandlerOptions,
+          "messageId"
+        >
+      }
+    | void
+    | null
+    | undefined
+  >
+  help: (interaction: CommandInteraction) => Promise<MessageOptions>
+  prepare: (
+    slashCommands?: Record<string, SlashCommand>
+  ) => Omit<SlashCommandBuilder, "addSubcommand" | "addSubcommandGroup">
+  choiceOptions?: SlashCommandChoiceOption[]
+  colorType: ColorType
+}
+
 // All command must conform to this type
 export type Command = {
   id: string
@@ -135,21 +165,4 @@ export type RepostReactionRequest = {
   emoji: string
   quantity?: number | 0
   repost_channel_id?: string | ""
-}
-
-export type SlashCommand = {
-  command: string
-  run: (interaction: CommandInteraction) => Promise<
-    | {
-        messageOptions: MessageOptions
-        commandChoiceOptions?: SetOptional<
-          CommandChoiceHandlerOptions,
-          "messageId"
-        >
-      }
-    | void
-    | null
-    | undefined
-  >
-  data: Omit<SlashCommandBuilder, "addSubcommand" | "addSubcommandGroup">
 }

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -1,6 +1,6 @@
-import { Message } from "discord.js"
+import { CommandInteraction, Message } from "discord.js"
 
-import { Command } from "types/common"
+import { Command, SlashCommand } from "types/common"
 import {
   CHANNEL_PREFIX,
   EMOJI_PREFIX,
@@ -12,6 +12,7 @@ import {
 } from "./constants"
 import { commands } from "commands"
 import { utils } from "ethers"
+import { slashCommands } from "index"
 
 export const getCommandArguments = (message: Message) => {
   const content = message?.content
@@ -54,6 +55,7 @@ export const getAllAliases = (
   }, commands)
 }
 
+// TODO: remove after slash command migration done
 export const getCommandObject = (msg?: Message | null): Command | null => {
   if (!msg) return null
   const args = getCommandArguments(msg)
@@ -137,3 +139,13 @@ export function parseDiscordToken(value: string) {
 //     })
 //     .join(SPACE)
 // }
+
+export function getSlashCommandObject(
+  interaction: CommandInteraction
+): SlashCommand | null {
+  if (!interaction) return null
+  // const args = getCommandArguments(msg)
+  // if (!args.length) return null
+  // const { commandKey } = getCommandMetadata(msg)
+  return slashCommands[interaction.commandName]
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -11,7 +11,7 @@ export const SPACES_REGEX = / +/g
 export const EMPTY = ""
 export const VERTICAL_BAR = "|"
 
-export const PREFIX = "$"
+export const PREFIX = "/"
 export const HELP = "help"
 export const HELP_CMD = `${PREFIX}${HELP}`
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2318,13 +2318,6 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
-  dependencies:
-    balanced-match "^1.0.0"
-
 braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
@@ -2881,7 +2874,7 @@ commander@^8.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
-commander@^9.3.0, commander@^9.4.0:
+commander@^9.4.0:
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
   integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
@@ -3042,13 +3035,6 @@ cron@^2.0.0:
   integrity sha512-RPeRunBCFr/WEo7WLp8Jnm45F/ziGJiHVvVQEBSDTSGu6uHW49b2FOP2O14DcXlGJRLhwE7TIoDzHHK4KmlL6g==
   dependencies:
     luxon "^1.23.x"
-
-cross-fetch@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
-  dependencies:
-    node-fetch "2.6.7"
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -3379,20 +3365,6 @@ dotenv@^10.0.0:
   version "10.0.0"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
-
-dtsgenerator@^3.16.0:
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/dtsgenerator/-/dtsgenerator-3.16.0.tgz#370e3d7563f7c2b763489988bc761b703b1801c6"
-  integrity sha512-aR9Z8FiBS6/sdj1XR9rvJsucSlX4VU8zH0LdExZhcx5QK465uAhKPHmQog/tlne5sQAOkBWl5Kd8QHF9zzxteg==
-  dependencies:
-    commander "^9.3.0"
-    cross-fetch "^3.1.5"
-    debug "^4.3.4"
-    glob "^8.0.3"
-    https-proxy-agent "^5.0.1"
-    js-yaml "^4.1.0"
-    tslib "^2.4.0"
-    typescript "^4.7.3"
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -4421,17 +4393,6 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
-  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
-
 global@~4.4.0:
   version "4.4.0"
   resolved "https://registry.npmjs.org/global/-/global-4.4.0.tgz"
@@ -4789,14 +4750,6 @@ https-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz"
   integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
-  dependencies:
-    agent-base "6"
-    debug "4"
-
-https-proxy-agent@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
-  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
     debug "4"
@@ -6370,13 +6323,6 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
-  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz"
@@ -6609,17 +6555,17 @@ node-fetch@2.6.2, node-fetch@^2.6.1:
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz"
   integrity sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==
 
-node-fetch@2.6.7, node-fetch@^2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 node-fetch@^2.6.5:
   version "2.6.6"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz"
   integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -8764,7 +8710,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.7.4, typescript@^4.5.5, typescript@^4.7.3, typescript@^4.7.4:
+typescript@4.7.4, typescript@^4.5.5, typescript@^4.7.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==


### PR DESCRIPTION
**What does this PR do?**
Continue slash commands migration
- [x] restrict/allow DM commands: add `SlashCommand.allowDM`
- [x] response embed color: add `SlashCommand.colorType`
- [x] help message: add `SlashCommand.help`
- [x] support autocomplete for arguments: see `SlashCommand.prepare` (refactor from `SlashCommand.data`)

**Media**
- [x] help messages
https://user-images.githubusercontent.com/34529672/188629300-2af280cb-d71a-48c6-a60d-d408b3be0352.mp4

- [x] DM commands
<img width="620" alt="image" src="https://user-images.githubusercontent.com/34529672/188629452-c75920bf-74a6-41d1-a77e-156b47e741fc.png">
