### PR TITLE
fix: enable zero amount config nftrole

### DIFF
--- a/src/commands/config/nftRole/index.ts
+++ b/src/commands/config/nftRole/index.ts
@@ -54,7 +54,7 @@ const command: Command = {
     }
 
     const amount = +amountArg
-    if (Number.isNaN(amount) || amount <= 0 || amount >= Infinity)
+    if (Number.isNaN(amount) || amount < 0 || amount >= Infinity)
       return {
         messageOptions: {
           embeds: [


### PR DESCRIPTION
**What does this PR do?**

-   [x] enable zero amount when config nftrole


**Media (Loom or gif)**

<img width="630" alt="Screen Shot 2022-09-08 at 11 37 30" src="https://user-images.githubusercontent.com/49946656/189035403-26549db9-1994-4797-a6d5-cadd320a5ddf.png">

