### PR TITLE
fix: profile faction xp emoji

### DIFF
--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -106,7 +106,9 @@ function buildXPbar(name: string, value: number) {
   return `${list
     .map((_, i) => {
       if (Math.floor((value / cap) * 10) >= i + 1) {
-        return i === 0 ? getEmoji(`${name}_exp_1`) : getEmoji(`${name}_exp_2`)
+        return i === 0
+          ? getEmoji(`${name}_exp_1`, true)
+          : getEmoji(`${name}_exp_2`, true)
       }
       return _
     })


### PR DESCRIPTION
**What does this PR do?**

-   [x] Use emoji with animated param set to true

Faction XP emojis are animated so we must set the 2nd param of `getEmoji` to true for it to render correctly
