### PR TITLE
fix: decrease faction xp length

### DIFF
--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -99,13 +99,13 @@ function buildProgressbar(progress: number): string {
 
 function buildXPbar(name: string, value: number) {
   const cap = Math.ceil(value / 1000) * 1000
-  const list = new Array(10).fill(getEmoji("faction_exp_2"))
+  const list = new Array(7).fill(getEmoji("faction_exp_2"))
   list[0] = getEmoji("faction_exp_1")
   list[list.length - 1] = getEmoji("faction_exp_3")
 
   return `${list
     .map((_, i) => {
-      if (Math.floor((value / cap) * 10) >= i + 1) {
+      if (Math.floor((value / cap) * 7) >= i + 1) {
         return i === 0
           ? getEmoji(`${name}_exp_1`, true)
           : getEmoji(`${name}_exp_2`, true)


### PR DESCRIPTION
**What does this PR do?**

-   [x] Decrease the faction xp length to 7 (10 will cause a new line in discord)

**Media**
We take 7 instead of 8 because safer value and won't cause newline
<img width="531" alt="CleanShot 2022-09-09 at 20 02 18@2x" src="https://user-images.githubusercontent.com/25856620/189356605-cd928083-ad55-4050-af0f-3767f219d847.png">