### PR TITLE
fix: dm command crash issue

### DIFF
--- a/src/errors/CommandNotAllowedToRunError.ts
+++ b/src/errors/CommandNotAllowedToRunError.ts
@@ -31,7 +31,7 @@ export class CommandNotAllowedToRunError extends BotBaseError {
 
   handle() {
     let errorEmbed
-    if (this.missingPermissions) {
+    if (this.missingPermissions?.length) {
       errorEmbed = getErrorEmbed({
         msg: this.discordMessage,
         title: `${defaultEmojis.ERROR} Insufficient permissions`,


### PR DESCRIPTION
**What does this PR do?**
-   [x] running a disallowed-DM command in DM will pass `missingPermissions` as empty array, which will cause `empty field value` error
-> Check length