### PR TITLE
fix: profile privacy logic

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1026,9 +1026,11 @@ export interface ResponseNFTCollectionConfig {
   address?: string;
   author?: string;
   chain_id?: string;
+  chain_name?: string;
   collection_id?: string;
   created_at?: string;
   erc_format?: string;
+  explorer_url?: string;
   id?: string;
   image?: string;
   is_verified?: boolean;


### PR DESCRIPTION
**What does this PR do?**

-   [x] Hide some private info (user address, wallet, protocol, nft value) if msg author is not an admin 

**How to test**
-  As an not admin user, use command $profile / $profile @other-user -> the private info will be mask with ***
- As an admin user, use command $profile / $profile @other-user -> the private info will be fully shown

**Media (Loom or gif)**

<img width="633" alt="CleanShot 2022-09-13 at 15 13 59@2x" src="https://user-images.githubusercontent.com/14150687/189848198-41725491-fa50-45d9-b555-a267ba020fec.png">

