### PR TITLE
chore: add chain id to nft role list

### DIFF
--- a/src/commands/config/nftRole/list.ts
+++ b/src/commands/config/nftRole/list.ts
@@ -21,9 +21,11 @@ export function list({ data }: ResponseListGuildGroupNFTRolesResponse) {
           }\` tokens\n${c.nft_collection_configs
             ?.map(
               (nftCol) =>
-                `${getEmoji("blank")}${getEmoji("reply")}\`${
+                `${getEmoji("blank")}${getEmoji("reply")}[\`${
                   nftCol.symbol?.toUpperCase() ?? ""
-                } ${shortenHashOrAddress(nftCol.address ?? "")}\``
+                } ${shortenHashOrAddress(nftCol.address ?? "")}${
+                  nftCol.chain_id ? ` (${nftCol.chain_id})` : ""
+                })\`](${nftCol.explorer_url || "https://getmochi.co/"})`
             )
             .join("\n")}`
       )


### PR DESCRIPTION
**What does this PR do?**

-   [x] Add chain id and embed link to explorer

**How to test**
```
$nr set <role> <amount> <address>
$nr list
```

**Edge cases**

-  In case of unidentifiable chain, chain id will not show

**Media (Loom or gif)**
<img width="441" alt="Xnapper-2022-09-13-16 01 41" src="https://user-images.githubusercontent.com/25856620/189861255-11b6da02-1d06-4520-a1cb-784648969065.png">

