### PR TITLE
fix: handle wl error cases

### DIFF
--- a/src/commands/defi/watchlist/remove.ts
+++ b/src/commands/defi/watchlist/remove.ts
@@ -1,14 +1,11 @@
 import { Command } from "types/common"
 import { thumbnails } from "utils/common"
-import {
-  getErrorEmbed,
-  getSuccessEmbed,
-  composeEmbedMessage,
-} from "utils/discordEmbed"
+import { getSuccessEmbed, composeEmbedMessage } from "utils/discordEmbed"
 import { PREFIX } from "utils/constants"
 import defi from "adapters/defi"
 import { getCommandArguments } from "utils/commands"
 import CacheManager from "utils/CacheManager"
+import { handleUpdateWlError } from "../watchlist_slash"
 
 const command: Command = {
   id: "watchlist_remove",
@@ -18,11 +15,11 @@ const command: Command = {
   run: async (msg) => {
     const symbol = getCommandArguments(msg)[2]
     const userId = msg.author.id
-    const { ok } = await defi.removeFromWatchlist({
+    const { ok, error } = await defi.removeFromWatchlist({
       userId,
       symbol,
     })
-    if (!ok) return { messageOptions: { embeds: [getErrorEmbed({})] } }
+    if (!ok) return handleUpdateWlError(symbol, error, true)
     CacheManager.findAndRemove("watchlist", `watchlist-${userId}-`)
     return {
       messageOptions: { embeds: [getSuccessEmbed({})] },

--- a/src/commands/defi/watchlist/view.ts
+++ b/src/commands/defi/watchlist/view.ts
@@ -162,7 +162,7 @@ const command: Command = {
     const userId = msg.author.id
     const { data, pagination, ok } = await CacheManager.get({
       pool: "watchlist",
-      key: `watchlist-${userId}-${page}`,
+      key: `watchlist-${userId}-${page}-8`,
       call: () => defi.getUserWatchlist({ userId, page, size: 8 }),
     })
     if (!ok) return { messageOptions: { embeds: [getErrorEmbed({})] } }

--- a/src/commands/defi/watchlist_slash/index.ts
+++ b/src/commands/defi/watchlist_slash/index.ts
@@ -1,7 +1,7 @@
 import { SlashCommand } from "types/common"
 import { CommandInteraction } from "discord.js"
 import { thumbnails } from "utils/common"
-import { composeEmbedMessage2 } from "utils/discordEmbed"
+import { composeEmbedMessage2, getErrorEmbed } from "utils/discordEmbed"
 import {
   SlashCommandBuilder,
   SlashCommandSubcommandBuilder,
@@ -11,6 +11,33 @@ import view from "./view"
 import add from "./add"
 import remove from "./remove"
 import CacheManager from "utils/CacheManager"
+
+export function handleUpdateWlError(
+  symbol: string,
+  error: string | null,
+  isRemove?: boolean
+) {
+  if (!error) return { messageOptions: { embeds: [getErrorEmbed({})] } }
+  let description
+  switch (true) {
+    case error.toLowerCase().startsWith("record not found"):
+      description = `Token with symbol \`${symbol}\` ${
+        isRemove ? "does not exist in your watchlist" : "is not supported"
+      }.`
+      break
+    case error.toLowerCase().startsWith("conflict") && !isRemove:
+      description = `Token already existed in your watchlist.`
+      break
+    default:
+      break
+  }
+  return {
+    messageOptions: {
+      embeds: [getErrorEmbed({ description })],
+      components: [],
+    },
+  }
+}
 
 CacheManager.init({
   ttl: 0,

--- a/src/commands/defi/watchlist_slash/remove.ts
+++ b/src/commands/defi/watchlist_slash/remove.ts
@@ -1,15 +1,12 @@
 import { SlashCommand } from "types/common"
 import { CommandInteraction } from "discord.js"
 import { thumbnails } from "utils/common"
-import {
-  getErrorEmbed,
-  getSuccessEmbed,
-  composeEmbedMessage2,
-} from "utils/discordEmbed"
+import { getSuccessEmbed, composeEmbedMessage2 } from "utils/discordEmbed"
 import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
 import { SLASH_PREFIX as PREFIX } from "utils/constants"
 import defi from "adapters/defi"
 import CacheManager from "utils/CacheManager"
+import { handleUpdateWlError } from "."
 
 const command: SlashCommand = {
   name: "remove",
@@ -30,11 +27,11 @@ const command: SlashCommand = {
   run: async function (interaction: CommandInteraction) {
     const symbol = interaction.options.getString("symbol", true)
     const userId = interaction.user.id
-    const { ok } = await defi.removeFromWatchlist({
+    const { ok, error } = await defi.removeFromWatchlist({
       userId,
       symbol,
     })
-    if (!ok) return { messageOptions: { embeds: [getErrorEmbed({})] } }
+    if (!ok) return handleUpdateWlError(symbol, error, true)
     CacheManager.findAndRemove("watchlist", `watchlist-${userId}-`)
     return { messageOptions: { embeds: [getSuccessEmbed({})] } }
   },

--- a/src/commands/defi/watchlist_slash/view.ts
+++ b/src/commands/defi/watchlist_slash/view.ts
@@ -173,7 +173,7 @@ const command: SlashCommand = {
     const userId = interaction.user.id
     const { data, pagination, ok } = await CacheManager.get({
       pool: "watchlist",
-      key: `watchlist-${userId}-${page}`,
+      key: `watchlist-${userId}-${page}-8`,
       call: () => defi.getUserWatchlist({ userId, page, size: 8 }),
     })
     if (!ok) return { messageOptions: { embeds: [getErrorEmbed({})] } }

--- a/src/commands/defi/watchlistcompact/view.ts
+++ b/src/commands/defi/watchlistcompact/view.ts
@@ -163,7 +163,7 @@ const command: Command = {
     const userId = msg.author.id
     const { data, ok } = await CacheManager.get({
       pool: "watchlist",
-      key: `watchlist-${userId}-0`,
+      key: `watchlist-${userId}-0-12`,
       call: () => defi.getUserWatchlist({ userId, size: 12 }),
     })
     if (!ok) return { messageOptions: { embeds: [getErrorEmbed({})] } }


### PR DESCRIPTION
**What does this PR do?**
Handle wl error cases
- [x] $wl add
1. duplicate item
2. symbol not exists/supported
- [x] $wl remove
2. symbol does not exist in user's wl

**Media**
<img width="501" alt="image" src="https://user-images.githubusercontent.com/34529672/190113755-955cbd22-aa58-4ebf-a8cb-09a12cd99e70.png">
<img width="379" alt="image" src="https://user-images.githubusercontent.com/34529672/190113838-82cbce21-bc11-4158-954d-4403000a8527.png">
