### PR TITLE
chore: cache upvote msg

### DIFF
--- a/src/adapters/community.ts
+++ b/src/adapters/community.ts
@@ -434,6 +434,18 @@ class Community extends Fetcher {
       }
     )
   }
+
+  public async setUpvoteMessageCache(req: {
+    user_id: string
+    guild_id: string
+    channel_id: string
+    message_id: string
+  }) {
+    return await this.jsonFetch(`${API_BASE_URL}/cache/upvote`, {
+      method: "POST",
+      body: JSON.stringify(req),
+    })
+  }
 }
 
 export default new Community()

--- a/src/commands/config/welcome_slash/info.ts
+++ b/src/commands/config/welcome_slash/info.ts
@@ -29,10 +29,6 @@ export async function welcomeInfo(interaction: CommandInteraction) {
 
   const configData = configs.data
   if (!configData) {
-    throw new Error(`Failed to get welcome channel response`)
-  }
-
-  if (!configData.welcome_message) {
     const embed = composeEmbedMessage(null, {
       author: [interaction.guild.name, interaction.guild.iconURL() ?? ""],
       description: `No welcome channel configured for this guild.\nSet one with \`${SLASH_PREFIX}welcome set <channel>.\``,


### PR DESCRIPTION
**What does this PR do?**

- `$vote` now calls API to cache message data
- fixed `/welcome` response
