### PR TITLE
fix: missing permission

### DIFF
--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -35,13 +35,15 @@ export default {
 
       for (const cache of client.guilds.cache) {
         const guild = cache[1]
-        const firstInvites = await guild.invites.fetch()
-        invites.set(
-          guild.id,
-          new Discord.Collection(
-            firstInvites.map((invite) => [invite.code, invite.uses ?? 0])
+        if (guild.me?.permissions.has("ADMINISTRATOR")) {
+          const firstInvites = await guild.invites.fetch()
+          invites.set(
+            guild.id,
+            new Discord.Collection(
+              firstInvites.map((invite) => [invite.code, invite.uses ?? 0])
+            )
           )
-        )
+        }
       }
 
       await wait(1000)


### PR DESCRIPTION
**What does this PR do?**

-   [x] fix: missing permission

**How to test**

- Server disable `ADMINISTRATOR` permission lead to when bot restart, event `ready` cannot get invites from this server.

**Media (Loom or gif)**

Error: 

![image](https://user-images.githubusercontent.com/104887632/190372267-7117925f-5549-451d-804b-3603571a916a.png)

