### PR TITLE
fix: invite aggregation

### DIFF
--- a/src/commands/community/invite/aggregation.ts
+++ b/src/commands/community/invite/aggregation.ts
@@ -17,7 +17,7 @@ const command: Command = {
     }
     const args = getCommandArguments(msg)
     const { isUser, id: inviterId } = parseDiscordToken(
-      args.length === 3 ? args[2] : msg.author.id
+      args.length === 3 ? args[2] : `<@${msg.author.id}>`
     )
     if (!isUser) {
       throw new CommandError({


### PR DESCRIPTION
**What does this PR do?**

-   [x] Because using the `parseDiscordToken` and check the `isUser` flag, we must use user format

**How to test**
`$invite aggregation`

**Media (Loom or gif)**
<img width="312" alt="CleanShot 2022-09-16 at 09 29 19@2x" src="https://user-images.githubusercontent.com/25856620/190543678-2f931702-6835-4afd-94d6-45ddbf1051dc.png">
<img width="438" alt="CleanShot 2022-09-16 at 09 29 36@2x" src="https://user-images.githubusercontent.com/25856620/190543704-5425a711-7809-4e81-8618-bae608f158a2.png">

