### PR TITLE
fix: vote top admin

### DIFF
--- a/src/commands/community/vote/top.ts
+++ b/src/commands/community/vote/top.ts
@@ -71,7 +71,7 @@ const command: Command = {
     ],
   }),
   colorType: "Server",
-  onlyAdministrator: true,
+  aliases: ["leaderboard"],
 }
 
 export default command


### PR DESCRIPTION
**What does this PR do?**

-   [x] Remove only admin check
-   [x] Add `leaderboard` alias to vote top command

**Media (Loom or gif)**
The bug
<img width="472" alt="CleanShot 2022-09-21 at 10 29 13@2x" src="https://user-images.githubusercontent.com/25856620/191407978-f74dc817-02c9-43cb-81ff-f0c513e1e21e.png">
