### PR TITLE
fix: gm streak msg when no config

### DIFF
--- a/src/commands/community/gm/streak.ts
+++ b/src/commands/community/gm/streak.ts
@@ -25,9 +25,18 @@ const command: Command = {
     }
     const res = await Profile.getUserGmStreak(msg.author.id, msg.guildId)
     if (!res.ok) {
-      switch (res.error) {
+      switch (res.error.toLowerCase()) {
         case "user has no gm streak":
-          return null
+          return {
+            messageOptions: {
+              embeds: [
+                composeEmbedMessage(msg, {
+                  title: `GM/GN streak`,
+                  description: `Please configure gm/gn channel first. Type ${PREFIX}help gm config for more information.`,
+                }),
+              ],
+            },
+          }
         default:
           throw new Error(res.error)
       }


### PR DESCRIPTION
**What does this PR do?**

-   [x] Fix message for gm streak when no gm config

**Media (Loom or gif)**
Before:

<img width="617" alt="Screen Shot 2022-09-21 at 14 46 47" src="https://user-images.githubusercontent.com/49946656/191445945-ed966833-03a9-4ea1-9574-2969e2628aa2.png">

After:
<img width="619" alt="Screen Shot 2022-09-21 at 14 47 23" src="https://user-images.githubusercontent.com/49946656/191446070-75d5e01a-b240-4808-8c51-70d83ecbc545.png">
