### PR TITLE
fix: leaderboard canvas

### DIFF
--- a/src/commands/community/vote/top.ts
+++ b/src/commands/community/vote/top.ts
@@ -37,7 +37,7 @@ const command: Command = {
         files: [
           await drawLeaderboard({
             rows: await Promise.all(
-              res.data.map(async (d) => {
+              res.data?.map(async (d) => {
                 const user = await msg.guild?.members.fetch(d.discord_id ?? "")
                 if (user) {
                   return {
@@ -52,7 +52,7 @@ const command: Command = {
                     rightValue: `${d.streak_count ?? 0}/${d.total_count ?? 0}`,
                   }
                 }
-              })
+              }) ?? []
             ),
             leftHeader: "Voters",
             rightHeader: "Streak/Total",

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -559,7 +559,10 @@ export async function drawLeaderboard(options: {
   // right title
   const rightTitleStr = options.rightHeader
   const rightTitle = {
-    x: 600,
+    x:
+      container.w -
+      widthOf(ctx, rightTitleStr) -
+      (container.pr ?? container.pl ?? 0),
     y: userTitle.y,
   }
   ctx.fillText(rightTitleStr, rightTitle.x, rightTitle.y ?? 0)
@@ -624,7 +627,10 @@ export async function drawLeaderboard(options: {
     ctx.font = "bold 27px Manrope"
     ctx.fillStyle = "#BFBFBF"
     const rightValue = {
-      x: rightTitle.x,
+      x:
+        container.w -
+        widthOf(ctx, rightStr) -
+        (container.pr ?? container.pl ?? 0),
       y: discriminator.y,
       w: widthOf(ctx, rightStr),
     }


### PR DESCRIPTION
**What does this PR do?**

-   [x] Leaderboard canvas right column are right aligned
-   [x] In `$vote top` command, if data is null default to empty array

**How to test**
`$vote top`
`$top`

**Media (Loom or gif)**
|Before|After|
|---|---|
|<img width="499" alt="CleanShot 2022-09-21 at 16 31 06@2x" src="https://user-images.githubusercontent.com/25856620/191469471-ec78b852-6ead-448e-804b-29cadfef51cb.png">|<img width="491" alt="CleanShot 2022-09-21 at 16 31 20@2x" src="https://user-images.githubusercontent.com/25856620/191469565-0eb3d585-e9c4-473e-a2aa-b020bd63a880.png">|


