### PR TITLE
feat: send intro msg to new guild

### DIFF
--- a/src/events/guildCreate.ts
+++ b/src/events/guildCreate.ts
@@ -5,6 +5,8 @@ import webhook from "adapters/webhook"
 import { BotBaseError } from "errors"
 import { logger } from "logger"
 import ChannelLogger from "utils/ChannelLogger"
+import { TextChannel } from "discord.js"
+import { composeEmbedMessage } from "utils/discordEmbed"
 
 export default {
   name: "guildCreate",
@@ -19,6 +21,7 @@ export default {
       await webhook.pushDiscordWebhook("guildCreate", {
         guild_id: guild.id,
       })
+      IntroduceMochiToAdmin(guild)
     } catch (e) {
       const error = e as BotBaseError
       if (error.handle) {
@@ -30,3 +33,40 @@ export default {
     }
   },
 } as Event<"guildCreate">
+
+async function IntroduceMochiToAdmin(guild: Discord.Guild) {
+  const introduceChannel = guild.channels.cache
+    .filter((c) => c.type == "GUILD_TEXT")
+    .map((c) => c as TextChannel)[0]
+
+  if (introduceChannel) {
+    introduceChannel.send({
+      embeds: [
+        composeEmbedMessage(null, {
+          title: `Hi ${guild.name} administrators!!!`,
+          description: `Thank you for using Mochi Bot to build your community! The first thing to do is type \`$help\` to explore all features or read our instructions on 
+          Gitbook. To build an optimal community, our Mochi Bot offers these functions:
+          \n• Config Good-morning channel: \`$gm\`
+          • Config channel to track member activity: \`$log\`
+          • Set up default and reaction role: \`$defaultrole\`, \`$reactionroles\`
+          • Set up a welcome message: \`/welcome\`
+          • Track server information: \`$stats\`
+          • Update Tweet from Twitter: \`$poe\`
+          \nOnly Administrators can use these commands. If you want others to use these commands, make them administrators. Run the command to build a community with Mochi now!!!
+          `,
+          color: `0xFCD3C1`,
+        }),
+        composeEmbedMessage(null, {
+          description: `Greeting new members by \`/welcome set\` and \`/welcome message\`.`,
+          image: `https://cdn.discordapp.com/attachments/701029345795375114/1022072432875548692/unknown.png`,
+          color: `0xFCD3C1`,
+        }),
+        composeEmbedMessage(null, {
+          description: `Config a good-morning channel to increase engagement by \`$gm config\``,
+          image: `https://cdn.discordapp.com/attachments/701029345795375114/1022072477200945183/unknown.png`,
+          color: `0xFCD3C1`,
+        }),
+      ],
+    })
+  }
+}

--- a/src/events/guildCreate.ts
+++ b/src/events/guildCreate.ts
@@ -21,7 +21,7 @@ export default {
       await webhook.pushDiscordWebhook("guildCreate", {
         guild_id: guild.id,
       })
-      IntroduceMochiToAdmin(guild)
+      introduceMochiToAdmin(guild)
     } catch (e) {
       const error = e as BotBaseError
       if (error.handle) {
@@ -34,7 +34,7 @@ export default {
   },
 } as Event<"guildCreate">
 
-async function IntroduceMochiToAdmin(guild: Discord.Guild) {
+async function introduceMochiToAdmin(guild: Discord.Guild) {
   const introduceChannel = guild.channels.cache
     .filter((c) => c.type == "GUILD_TEXT")
     .map((c) => c as TextChannel)[0]


### PR DESCRIPTION
- Send intro msg when Mochi joins new guild
- Discord doesnt have `Moderation channel` so i will send to first text channel which Mochi can access, Mochi has administrator so it can see most of channel
<img width="510" alt="image" src="https://user-images.githubusercontent.com/39881166/191478733-37e52424-84a0-40cc-bb83-1b33928f22c1.png">
