### PR TITLE
fix: fix case for list and info or streak

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -294,19 +294,16 @@ export default async function handlePrefixedCommand(message: Message) {
     actionObject?.command ?? "",
     message.content
   )
-  const valid =
-    validateCommand(
-      finalCmd,
-      args,
-      !!actionObject,
-      isSpecificHelpCommand ?? false
-    ) || shouldShowHelp
-  if (shouldShowHelp) {
+  const valid = validateCommand(
+    finalCmd,
+    args,
+    !!actionObject,
+    isSpecificHelpCommand ?? false
+  )
+  if (shouldShowHelp && !valid) {
     message.content = `${HELP} ${commandKey} ${action}`.trimEnd()
     isSpecificHelpCommand = true
-  }
-  if (!valid) {
-    message.content = `${HELP} ${commandKey} ${action}`.trimEnd()
+  } else if (!valid) {
     throw new CommandArgumentError({
       message: message,
       getHelpMessage: () => finalCmd.getHelpMessage(message, action),


### PR DESCRIPTION
**What does this PR do?**

-   [x] Fix for case command such as $lr list, $gm info, ... not to show help cmd.

**Media (Loom or gif)**
![image](https://user-images.githubusercontent.com/49946656/192203867-ebd77512-1744-4585-ba36-e20f9495c31b.png)

For case $nr, $nr set, .. still show help cmd without alert
![image](https://user-images.githubusercontent.com/49946656/192202571-88e404b9-9e4b-48d1-bbb4-326bc7b924d4.png)
![image](https://user-images.githubusercontent.com/49946656/192202666-1023518b-5a2f-4d43-83b1-ef8ca0525ca7.png)
