### PR TITLE
fix: remove admin only

### DIFF
--- a/src/commands/defi/token/info.ts
+++ b/src/commands/defi/token/info.ts
@@ -114,7 +114,6 @@ const command: Command = {
   id: "info_server_token",
   command: "info",
   brief: "Information of a token",
-  onlyAdministrator: true,
   category: "Community",
   run: async function (msg) {
     if (!msg.guildId) {


### PR DESCRIPTION
**What does this PR do?**

-   [x] Remove only admin for cmd token info

**Media (Loom or gif)**
Error: 
<img width="424" alt="Screen Shot 2022-09-28 at 11 23 59" src="https://user-images.githubusercontent.com/49946656/192687167-b7141ff7-26a4-4741-97bf-47901fda92cf.png">
