### PR TITLE
fix: edit unknown message

### DIFF
--- a/src/commands/community/nft/query.ts
+++ b/src/commands/community/nft/query.ts
@@ -235,7 +235,7 @@ export async function setDefaultSymbol(i: ButtonInteraction) {
   i.editReply({
     embeds: [embed],
     components: [],
-  })
+  }).catch(() => null)
 }
 
 function addSuggestionIfAny(
@@ -395,18 +395,20 @@ const command: Command = {
           if (!shouldAskDefault) {
             await i.deferUpdate()
           }
-          await replyMsg?.edit({
-            embeds: [
-              await composeNFTDetail(
-                res.data,
-                msg,
-                detailRes.data.name,
-                detailRes.data.image,
-                detailRes.data.chain?.name
-              ),
-            ],
-            ...addSuggestionIfAny(symbol, tokenId, res.suggestions),
-          })
+          await replyMsg
+            ?.edit({
+              embeds: [
+                await composeNFTDetail(
+                  res.data,
+                  msg,
+                  detailRes.data.name,
+                  detailRes.data.image,
+                  detailRes.data.chain?.name
+                ),
+              ],
+              ...addSuggestionIfAny(symbol, tokenId, res.suggestions),
+            })
+            .catch(() => null)
           if (shouldAskDefault) {
             const actionRow = new MessageActionRow().addComponents(
               new MessageButton({

--- a/src/commands/community/sales/remove.ts
+++ b/src/commands/community/sales/remove.ts
@@ -63,7 +63,7 @@ async function undo(i: ButtonInteraction) {
     i.editReply({
       embeds: [embed],
       ...(state === "queued-detail" ? { components: [] } : { components }),
-    })
+    }).catch(() => null)
     buttonCollector?.stop()
     buttonCollector = null
   }
@@ -76,7 +76,9 @@ async function selectRemove(i: SelectMenuInteraction) {
     if (res.ok) {
       const timeoutId = remove(i.guildId, contractAddress, () => {
         if (i.message instanceof Message) {
-          i.message.edit({ components: [i.message.components[0]] })
+          i.message
+            .edit({ components: [i.message.components[0]] })
+            .catch(() => null)
         }
       })
       const { embed, components } = renderResponse(
@@ -89,10 +91,12 @@ async function selectRemove(i: SelectMenuInteraction) {
         i.channelId,
         timeoutId
       )
-      const msg = await i.editReply({
-        embeds: [embed],
-        components,
-      })
+      const msg = await i
+        .editReply({
+          embeds: [embed],
+          components,
+        })
+        .catch(() => null)
       buttonCollector = collectButton(msg as Message, i.user.id)
     }
   }
@@ -121,7 +125,7 @@ function collectSelect(msg: Message, authorId: string) {
     })
     .on("collect", selectRemove)
     .on("end", () => {
-      msg.edit({ components: [] })
+      msg.edit({ components: [] }).catch(() => null)
     })
 }
 
@@ -235,7 +239,7 @@ const command: Command = {
     let replyMsg: Message | null = null
     if (isAddress && id) {
       const timeoutId = remove(msg.guildId, id, () => {
-        replyMsg?.edit({ components: [] })
+        replyMsg?.edit({ components: [] }).catch(() => null)
       })
 
       const { embed, components } = renderResponse(

--- a/src/commands/config/globalxp.ts
+++ b/src/commands/config/globalxp.ts
@@ -28,18 +28,20 @@ export async function confirmGlobalXP(
     guildId: interaction.guildId,
     globalXP: `${globalXP}`,
   })
-  await msg.edit({
-    embeds: [
-      composeEmbedMessage(msg, {
-        author: [
-          `Global XP ${globalXP ? "enabled" : "disabled"}`,
-          msg.guild?.iconURL() ?? "",
-        ],
-        description: `You can check your global XP with \`$profile\``,
-      }),
-    ],
-    components: [],
-  })
+  await msg
+    .edit({
+      embeds: [
+        composeEmbedMessage(msg, {
+          author: [
+            `Global XP ${globalXP ? "enabled" : "disabled"}`,
+            msg.guild?.iconURL() ?? "",
+          ],
+          description: `You can check your global XP with \`$profile\``,
+        }),
+      ],
+      components: [],
+    })
+    .catch(() => null)
 }
 
 const command: Command = {

--- a/src/commands/defi/airdrop.ts
+++ b/src/commands/defi/airdrop.ts
@@ -81,19 +81,22 @@ export async function confirmAirdrop(
     originalMsgAuthor: originalAuthor?.user,
   })
 
-  const reply = await msg.edit({
-    embeds: [airdropEmbed],
-    components: [
-      new MessageActionRow().addComponents(
-        new MessageButton({
-          customId: `enter_airdrop-${authorId}-${duration}-${maxEntries}`,
-          label: "Enter airdrop",
-          style: "PRIMARY",
-          emoji: "🎉",
-        })
-      ),
-    ],
-  })
+  const reply = await msg
+    .edit({
+      embeds: [airdropEmbed],
+      components: [
+        new MessageActionRow().addComponents(
+          new MessageButton({
+            customId: `enter_airdrop-${authorId}-${duration}-${maxEntries}`,
+            label: "Enter airdrop",
+            style: "PRIMARY",
+            emoji: "🎉",
+          })
+        ),
+      ],
+    })
+    .catch(() => null)
+  if (!reply) return
   const cacheKey = `airdrop-${reply.id}`
   airdropCache.set(cacheKey, [], +duration)
 
@@ -150,17 +153,19 @@ async function checkExpiredAirdrop(
       }
 
       const originalAuthor = await msg.guild?.members.fetch(authorId)
-      msg.edit({
-        embeds: [
-          composeEmbedMessage(msg, {
-            title: `${defaultEmojis.AIRPLANE} An airdrop appears`,
-            footer: [`${participants.length} users joined, ended`],
-            description,
-            originalMsgAuthor: originalAuthor?.user,
-          }),
-        ],
-        components: [],
-      })
+      msg
+        .edit({
+          embeds: [
+            composeEmbedMessage(msg, {
+              title: `${defaultEmojis.AIRPLANE} An airdrop appears`,
+              footer: [`${participants.length} users joined, ended`],
+              description,
+              originalMsgAuthor: originalAuthor?.user,
+            }),
+          ],
+          components: [],
+        })
+        .catch(() => null)
     }
   })
 }

--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -115,7 +115,7 @@ function collectButton(
       }
     })
     .on("end", () => {
-      msg.edit({ components: [] })
+      msg.edit({ components: [] }).catch(() => null)
     })
 }
 
@@ -141,10 +141,12 @@ async function switchView(
       ))
       break
   }
-  await i.editReply({
-    embeds: [embed],
-    components: components,
-  })
+  await i
+    .editReply({
+      embeds: [embed],
+      components: components,
+    })
+    .catch(() => null)
 }
 
 async function handlePagination(
@@ -164,10 +166,12 @@ async function handlePagination(
     currentCollectionAddress,
     page
   )
-  await i.editReply({
-    embeds: [embed],
-    components: components,
-  })
+  await i
+    .editReply({
+      embeds: [embed],
+      components: components,
+    })
+    .catch(() => null)
 }
 
 function collectSelectMenu(msg: Message, authorId: string, user: User) {
@@ -181,7 +185,7 @@ function collectSelectMenu(msg: Message, authorId: string, user: User) {
       await selectCollection(i, msg, user)
     })
     .on("end", () => {
-      msg.edit({ components: [] })
+      msg.edit({ components: [] }).catch(() => null)
     })
 }
 
@@ -196,10 +200,12 @@ async function selectCollection(
     user,
     currentCollectionAddress
   )
-  await i.editReply({
-    embeds: [embed],
-    components: components,
-  })
+  await i
+    .editReply({
+      embeds: [embed],
+      components: components,
+    })
+    .catch(() => null)
 }
 
 function buildProgressbar(progress: number): string {

--- a/src/commands/profile/verify.ts
+++ b/src/commands/profile/verify.ts
@@ -29,7 +29,7 @@ export async function sendVerifyURL(interaction: ButtonInteraction) {
         .setDescription(
           `\`\`\`${json.address}\`\`\`\nIf you want to change your address, [click here](${WEBSITE_ENDPOINT}/verify?code=${reverify.code}) to re-verify.`
         )
-      await interaction.editReply({ embeds: [e1] })
+      await interaction.editReply({ embeds: [e1] }).catch(() => null)
       break
     }
     case undefined: {
@@ -45,7 +45,9 @@ export async function sendVerifyURL(interaction: ButtonInteraction) {
           .setStyle("LINK")
           .setURL(`${WEBSITE_ENDPOINT}/verify?code=${json.code}`)
       )
-      await interaction.editReply({ embeds: [e2], components: [row] })
+      await interaction
+        .editReply({ embeds: [e2], components: [row] })
+        .catch(() => null)
       break
     }
     default:

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -95,12 +95,14 @@ async function handleCommandInteraction(interaction: Interaction) {
     // user is already using $vote, no point in reminding
     shouldRemind = false
   }
-  const reply = <Message>await i.editReply({
-    ...(shouldRemind
-      ? { content: "> 👋 Psst! You can vote now, try `$vote`. 😉" }
-      : {}),
-    ...messageOptions,
-  })
+  const reply = <Message>await i
+    .editReply({
+      ...(shouldRemind
+        ? { content: "> 👋 Psst! You can vote now, try `$vote`. 😉" }
+        : {}),
+      ...messageOptions,
+    })
+    .catch(() => null)
   if (commandChoiceOptions) {
     CommandChoiceManager.add({
       ...commandChoiceOptions,
@@ -116,13 +118,16 @@ async function handleSelecMenuInteraction(interaction: Interaction) {
   const commandChoice = await CommandChoiceManager.get(key)
   if (!commandChoice || !commandChoice.handler) return
   if (i.customId === "exit") {
-    await msg.delete().catch(() => {
-      commandChoice.interaction?.editReply({
-        content: "Exited!",
-        components: [],
-        embeds: [],
+    await msg
+      .delete()
+      .catch(() => {
+        commandChoice.interaction?.editReply({
+          content: "Exited!",
+          components: [],
+          embeds: [],
+        })
       })
-    })
+      .catch(() => null)
     CommandChoiceManager.remove(key)
     return
   }
@@ -135,10 +140,12 @@ async function handleSelecMenuInteraction(interaction: Interaction) {
   if (ephemeralMessage && deferredOrReplied) {
     // already deferred or replied in commandChoice.handler()
     // we do this for long-response command (> 3s) to prevent bot from throwing "Unknown interaction" error
-    output = <Message>await i.editReply({
-      embeds: ephemeralMessage.embeds,
-      components: ephemeralMessage.components,
-    })
+    output = <Message>await i
+      .editReply({
+        embeds: ephemeralMessage.embeds,
+        components: ephemeralMessage.components,
+      })
+      .catch(() => null)
   } else if (ephemeralMessage && !deferredOrReplied) {
     output = <Message>await i.reply({
       ephemeral: true,
@@ -166,7 +173,7 @@ async function handleSelecMenuInteraction(interaction: Interaction) {
         i.editReply({
           embeds: result.embeds,
           components: result.components ?? [],
-        })
+        }).catch(() => null)
       })
   }
 
@@ -176,7 +183,7 @@ async function handleSelecMenuInteraction(interaction: Interaction) {
     messageId: output?.id,
   })
   i
-  await msg.edit(messageOptions)
+  await msg.edit(messageOptions).catch(() => null)
 }
 
 async function handleButtonInteraction(interaction: Interaction) {

--- a/src/events/messageReactionAdd.ts
+++ b/src/events/messageReactionAdd.ts
@@ -62,10 +62,12 @@ const handleRepostableMessageTracking = async (
           channel.messages
             .fetch(`${res?.data.repost_message_id}`)
             .then((msg) => {
-              msg.edit({
-                embeds: [embed],
-                content: `**${reaction} ${reaction_count}** <#${channel_id}>`,
-              })
+              msg
+                .edit({
+                  embeds: [embed],
+                  content: `**${reaction} ${reaction_count}** <#${channel_id}>`,
+                })
+                .catch(() => null)
             })
         }
       }

--- a/src/utils/CommandChoiceManager.ts
+++ b/src/utils/CommandChoiceManager.ts
@@ -128,11 +128,13 @@ export class CommandChoiceManager {
     const timeoutId = global.setTimeout(async () => {
       const response = await getInactivityResponse?.(user)
       if (interaction) {
-        await interaction.editReply({
-          content: "Exited!",
-          embeds: [],
-          components: [],
-        })
+        await interaction
+          .editReply({
+            content: "Exited!",
+            embeds: [],
+            components: [],
+          })
+          .catch(() => null)
       } else {
         const message = await channel.messages.fetch(messageId ?? "")
         await message.delete()

--- a/src/utils/discordEmbed.ts
+++ b/src/utils/discordEmbed.ts
@@ -350,11 +350,15 @@ export async function renderPaginator(msg: Message, pages: MessageEmbed[]) {
     if (i.user.id !== msg.author.id) return
     if (i.customId === "FORWARD_BTN") {
       page = page > 0 ? page - 1 : pages.length - 1
-      await message.edit({ embeds: [pages[page]], components: [row] })
+      await message
+        .edit({ embeds: [pages[page]], components: [row] })
+        .catch(() => null)
     }
     if (i.customId === "BACKWARD_BTN") {
       page = page < pages.length - 1 ? page + 1 : 0
-      await message.edit({ embeds: [pages[page]], components: [row] })
+      await message
+        .edit({ embeds: [pages[page]], components: [row] })
+        .catch(() => null)
     }
   })
 }
@@ -419,7 +423,7 @@ export function listenForSuggestionAction(
       }
     })
     .on("end", () => {
-      replyMsg.edit({ components: [] })
+      replyMsg.edit({ components: [] }).catch(() => null)
     })
 
   replyMsg
@@ -449,7 +453,7 @@ export function listenForSuggestionAction(
       }
     })
     .on("end", () => {
-      replyMsg.edit({ components: [] })
+      replyMsg.edit({ components: [] }).catch(() => null)
     })
 }
 
@@ -485,20 +489,24 @@ export function listenForPaginateAction(
         : getPaginationRow(page, +totalPage)
       if (withAttachmentUpdate && files?.length) {
         await replyMsg.removeAttachments()
-        await replyMsg.edit({
-          embeds,
-          components: msgComponents,
-          files,
-        })
+        await replyMsg
+          .edit({
+            embeds,
+            components: msgComponents,
+            files,
+          })
+          .catch(() => null)
       } else {
-        await replyMsg.edit({
-          embeds,
-          components: msgComponents,
-        })
+        await replyMsg
+          .edit({
+            embeds,
+            components: msgComponents,
+          })
+          .catch(() => null)
       }
     })
     .on("end", () => {
-      replyMsg.edit({ components: [] })
+      replyMsg.edit({ components: [] }).catch(() => null)
     })
 }
 


### PR DESCRIPTION
**What does this PR do?**

-   [x] Fix editing an unknown/already deleted message crash the bot

** Solution **
Add catch clause wherever an `edit` or `editReply` method is called, because we cannot traceback the origin from the stacktrace

**How to test**
`$profile`
remove the message -> mochi bot will throw discord error

**Media (Loom or gif)**
https://share.cleanshot.com/ihkoXr
