### PR TITLE
feat: handle bot removed event

### DIFF
--- a/src/adapters/config.ts
+++ b/src/adapters/config.ts
@@ -463,21 +463,13 @@ class Config extends Fetcher {
     globalXP?: string
     logChannel?: string
   }) {
-    const res = await fetch(`${API_BASE_URL}/guilds/${guildId}`, {
+    return await this.jsonFetch(`${API_BASE_URL}/guilds/${guildId}`, {
       method: "PUT",
-      body: JSON.stringify({
-        global_xp: globalXP ?? "",
-        log_channel: logChannel ?? "",
-      }),
+      body: {
+        ...(globalXP && { global_xp: globalXP }),
+        ...(logChannel && { log_channel: logChannel }),
+      },
     })
-    if (res.status !== 200) {
-      throw new Error(`failed to toggle guild global XP - guild ${guildId}`)
-    }
-
-    const json = await res.json()
-    if (json.error !== undefined) {
-      throw new Error(json.error)
-    }
   }
 
   public async newGuildNFTRoleConfig(body: RequestConfigGroupNFTRoleRequest) {

--- a/src/events/guildDelete.ts
+++ b/src/events/guildDelete.ts
@@ -1,0 +1,31 @@
+import { Event } from "."
+import Discord from "discord.js"
+import webhook from "adapters/webhook"
+import { BotBaseError } from "errors"
+import { logger } from "logger"
+import ChannelLogger from "utils/ChannelLogger"
+
+export default {
+  name: "guildDelete",
+  once: false,
+  execute: async (guild: Discord.Guild) => {
+    logger.info(`Left guild: ${guild.name} (id: ${guild.id}).`)
+
+    try {
+      const data = {
+        guild_id: guild.id,
+        guild_name: guild.name,
+        icon_url: guild.iconURL({ format: "png" }),
+      }
+      await webhook.pushDiscordWebhook("guildDelete", data)
+    } catch (e) {
+      const error = e as BotBaseError
+      if (error.handle) {
+        error.handle()
+      } else {
+        logger.error(e as string)
+      }
+      ChannelLogger.log(error, 'Event<"guildDelete">')
+    }
+  },
+} as Event<"guildDelete">

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -9,6 +9,7 @@ import inviteDelete from "./inviteDelete"
 import inviteCreate from "./inviteCreate"
 import messageReactionRemove from "./messageReactionRemove"
 import messageDelete from "./messageDelete"
+import guildDelete from "./guildDelete"
 
 export type Event<T extends keyof ClientEvents> = {
   name: T
@@ -25,8 +26,9 @@ export default [
   interactionCreate,
   messageReactionAdd,
   messageReactionRemove,
-  guildCreate,
   guildMemberAdd,
   inviteCreate,
   inviteDelete,
+  guildCreate,
+  guildDelete,
 ]


### PR DESCRIPTION
**What does this PR do?**
- [x] Handle event `guildDelete` (fired when bot leaves guild for any reason): send guild data to `/webhook/discord` to handle in BE