### PR TITLE
chore: update welcome

### DIFF
--- a/src/commands/config/welcome_slash/index.ts
+++ b/src/commands/config/welcome_slash/index.ts
@@ -14,6 +14,7 @@ const command: SlashCommand = {
     const data = new SlashCommandBuilder()
       .setName("welcome")
       .setDescription("Welcome new members to the guild")
+      .setDefaultPermission(false) //hide command from everyone but admin
 
     data
       .addSubcommand(info)

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -192,7 +192,7 @@ async function welcomeNewMember(member: Discord.GuildMember) {
   }
 
   const embed = composeEmbedMessage(null, {
-    title: "Nice to meet you",
+    title: ":wave: Nice to meet you :wave:",
     description: configData.welcome_message
       .replaceAll("$name", `<@${member.id}>`)
       .replaceAll(`\\n`, "\n"),

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -129,6 +129,7 @@ export interface ModelConfigXpLevel {
 }
 
 export interface ModelDiscordGuild {
+  active?: boolean;
   alias?: string;
   bot_scopes?: string[];
   created_at?: string;
@@ -580,7 +581,8 @@ export interface RequestTwitterPost {
 }
 
 export interface RequestUpdateGuildRequest {
-  global_xp?: string;
+  active?: boolean;
+  global_xp?: boolean;
   log_channel?: string;
 }
 
@@ -818,6 +820,7 @@ export interface ResponseGetGuildPruneExcludeResponse {
 }
 
 export interface ResponseGetGuildResponse {
+  active?: boolean;
   alias?: string;
   bot_scopes?: string[];
   global_xp?: boolean;


### PR DESCRIPTION
**What does this PR do?**

- Update welcome UI
- Changed `welcome` to admin only

Non-admin trying to use `welcome`
![image](https://user-images.githubusercontent.com/84314071/192938519-ffcaa4c8-a0f4-4b9b-9e94-2393a6226290.png)

New UI
![image](https://user-images.githubusercontent.com/84314071/192938576-5ab744af-5412-48a4-8f6a-f9ebaffbd54a.png)


