### PR TITLE
fix: scope some slash commands to admin only

### DIFF
--- a/src/commands/community/prune_slash/index.ts
+++ b/src/commands/community/prune_slash/index.ts
@@ -9,11 +9,11 @@ import { CommandInteraction } from "discord.js"
 const command: SlashCommand = {
   name: "prune",
   category: "Community",
+  onlyAdministrator: true,
   prepare: () => {
     const data = new SlashCommandBuilder()
       .setName("prune")
       .setDescription("Prune members")
-      .setDefaultPermission(false)
 
     data.addSubcommand(inactive).addSubcommand(without)
     return data

--- a/src/commands/community/verify_slash/index.ts
+++ b/src/commands/community/verify_slash/index.ts
@@ -10,6 +10,7 @@ import { CommandInteraction } from "discord.js"
 const command: SlashCommand = {
   name: "verify",
   category: "Community",
+  onlyAdministrator: true,
   prepare: () => {
     const data = new SlashCommandBuilder()
       .setName("verify")

--- a/src/commands/config/defaultRole_slash/index.ts
+++ b/src/commands/config/defaultRole_slash/index.ts
@@ -19,6 +19,7 @@ const subCommands: Record<string, SlashCommand> = {
 const command: SlashCommand = {
   name: "defaultrole",
   category: "Config",
+  onlyAdministrator: true,
   prepare: () => {
     const data = new SlashCommandBuilder()
       .setName("defaultrole")

--- a/src/commands/config/levelRole_slash/index.ts
+++ b/src/commands/config/levelRole_slash/index.ts
@@ -19,6 +19,7 @@ const subCommands: Record<string, SlashCommand> = {
 const command: SlashCommand = {
   name: "levelrole",
   category: "Config",
+  onlyAdministrator: true,
   prepare: () => {
     const data = new SlashCommandBuilder()
       .setName("levelrole")

--- a/src/commands/config/log_slash/index.ts
+++ b/src/commands/config/log_slash/index.ts
@@ -8,6 +8,7 @@ import { composeEmbedMessage } from "utils/discordEmbed"
 const command: SlashCommand = {
   name: "log",
   category: "Config",
+  onlyAdministrator: true,
   prepare: () => {
     const data = new SlashCommandBuilder()
       .setName("log")

--- a/src/commands/config/welcome_slash/index.ts
+++ b/src/commands/config/welcome_slash/index.ts
@@ -10,11 +10,11 @@ import { composeEmbedMessage } from "utils/discordEmbed"
 const command: SlashCommand = {
   name: "welcome",
   category: "Config",
+  onlyAdministrator: true,
   prepare: () => {
     const data = new SlashCommandBuilder()
       .setName("welcome")
       .setDescription("Welcome new members to the guild")
-      .setDefaultPermission(false) //hide command from everyone but admin
 
     data
       .addSubcommand(info)

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -9,6 +9,7 @@ import {
   Message,
   Interaction,
   CommandInteraction,
+  Permissions,
 } from "discord.js"
 import { MessageComponentTypes } from "discord.js/typings/enums"
 import CommandChoiceManager from "utils/CommandChoiceManager"
@@ -49,6 +50,21 @@ async function handleCommandInteraction(interaction: Interaction) {
   const command = slashCommands[i.commandName]
   if (!command) {
     await i.reply({ embeds: [getErrorEmbed({})] })
+    return
+  }
+  if (
+    command.onlyAdministrator &&
+    !i.memberPermissions?.has(Permissions.FLAGS.ADMINISTRATOR)
+  ) {
+    await i.reply({
+      embeds: [
+        getErrorEmbed({
+          title: "Insufficient permissions",
+          description:
+            "Only Administrators of this server can run this command.",
+        }),
+      ],
+    })
     return
   }
   await i.deferReply({ ephemeral: command?.ephemeral })

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -9,7 +9,6 @@ import {
   Message,
   Interaction,
   CommandInteraction,
-  Permissions,
 } from "discord.js"
 import { MessageComponentTypes } from "discord.js/typings/enums"
 import CommandChoiceManager from "utils/CommandChoiceManager"
@@ -20,6 +19,7 @@ import community from "adapters/community"
 import { wrapError } from "utils/wrapError"
 import { handleTickerViews } from "commands/defi/ticker"
 import { handleNFTTickerViews } from "commands/community/nft/ticker"
+import { hasAdministrator } from "utils/common"
 
 const event: DiscordEvent<"interactionCreate"> = {
   name: "interactionCreate",
@@ -52,10 +52,8 @@ async function handleCommandInteraction(interaction: Interaction) {
     await i.reply({ embeds: [getErrorEmbed({})] })
     return
   }
-  if (
-    command.onlyAdministrator &&
-    !i.memberPermissions?.has(Permissions.FLAGS.ADMINISTRATOR)
-  ) {
+  const gMember = interaction?.guild?.members.cache.get(interaction?.user.id)
+  if (command.onlyAdministrator && !hasAdministrator(gMember)) {
     await i.reply({
       embeds: [
         getErrorEmbed({

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -43,6 +43,7 @@ export type SlashCommandChoiceOption = {
 export type SlashCommand = {
   name: string
   category: Category
+  onlyAdministrator?: boolean
   prepare: (
     slashCommands?: Record<string, SlashCommand>
   ) =>


### PR DESCRIPTION
**What does this PR do?**

-   [x] Block user from using some admin-only commands

We can no longer hide/show slash commands for a specific role by code anymore. To achieve this, we have to setting this from the client side  `Settings > Integrations > Your application > Manage`

https://stackoverflow.com/questions/72339242/discord-js-trying-to-set-slash-command-permissions

**How to test**

- As a non-admin user use these commands `/defaultrole` | `/levelrole` | `/prune` | `/log` | `/welcome`

**Media (Loom or gif)**
![CleanShot 2022-10-06 at 15 25 44@2x](https://user-images.githubusercontent.com/14150687/194261443-412d2a2e-9d2d-42e5-a3bf-eda60051cf2a.png)

