### PR TITLE
fix: update styling nft ticker and add link to contract address

### DIFF
--- a/src/commands/community/nft/ticker.ts
+++ b/src/commands/community/nft/ticker.ts
@@ -27,6 +27,7 @@ import {
   emojis,
   getEmoji,
   getEmojiURL,
+  getMarketplaceCollectionUrl,
   roundFloatNumber,
   shortenHashOrAddress,
 } from "utils/common"
@@ -175,21 +176,24 @@ async function composeCollectionInfoEmbed(
   }
   const symbol = `${data.symbol?.toUpperCase() ?? "-"}`
   const address = data.address
-    ? `\`${shortenHashOrAddress(data.address)}\``
+    ? `[${shortenHashOrAddress(data.address)}](${getMarketplaceCollectionUrl(
+        data.address
+      )})`
     : "-"
   const name = `${data.name ?? "-"}`
   const desc = `${data.description ?? "-"}`
-  const discord = data.discord ? `[Link](${data.discord})` : "-"
-  const twitter = data.twitter ? `[Link](${data.twitter})` : "-"
-  const website = data.website ? `[Link](${data.website})` : "-"
+  const discord = data.discord
+    ? `[${getEmoji("discord")}](${data.discord})`
+    : ""
+  const twitter = data.twitter
+    ? `[${getEmoji("twitter")}](${data.twitter})`
+    : ""
+  const website = data.website ? `[🌐](${data.website})` : ""
+  const more = `${discord} ${twitter} ${website}`
   const ercFormat = `${data.erc_format ?? "-"}`
   const marketplaces = data.marketplaces
     ? data.marketplaces.map((m: string) => getEmoji(m)).join(" ")
     : "-"
-  let createdTime = "-"
-  if (data.created_at) {
-    createdTime = dayjs(data.created_at).format("DD/MM/YYYY")
-  }
   const fields = [
     {
       name: "Symbol",
@@ -212,20 +216,8 @@ async function composeCollectionInfoEmbed(
       value: ercFormat,
     },
     {
-      name: "Created at",
-      value: createdTime,
-    },
-    {
-      name: `Website`,
-      value: website,
-    },
-    {
-      name: `Discord`,
-      value: discord,
-    },
-    {
-      name: `Twitter`,
-      value: twitter,
+      name: "Find More",
+      value: more,
     },
   ].map((f: EmbedFieldData) => ({
     ...f,

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -168,6 +168,8 @@ export const emojis: { [key: string]: string } = {
   PREDICTION: "931194309385003058",
   FELLOWSHIP: "922044644928421888",
   TRADE: "1026414280498757652",
+  DISCORD: "1027525031451967498",
+  TWITTER: "1027525033280680026",
   ...tokenEmojis,
   ...numberEmojis,
   ...rarityEmojis,


### PR DESCRIPTION
**What does this PR do?**

-   [x] Remove the `created at` field since the data is incorrect
-   [x] Combine the external links in 1 place
-   [x] Embed Rarepepe website link to address field

**How to test**

-   `$nft ticker neko` > select Info

**Media (Loom or gif)**
<img width="707" alt="CleanShot 2022-10-06 at 17 32 28@2x" src="https://user-images.githubusercontent.com/14150687/194291489-8701ceeb-1f01-4976-9fda-8211411d906c.png">

