### PR TITLE
fix: temp fix for watchlist view unknown message

### DIFF
--- a/src/commands/defi/watchlist/view.ts
+++ b/src/commands/defi/watchlist/view.ts
@@ -369,7 +369,7 @@ function collectButton(msg: Message, originMsg: Message) {
       await switchView(i, msg, originMsg)
     })
     .on("end", () => {
-      msg.edit({ components: [] })
+      msg.edit({ components: [] }).catch(() => null)
     })
 }
 
@@ -391,11 +391,13 @@ async function switchView(
       ;({ embeds, files, components } = await composeTokenWatchlist(originMsg))
       break
   }
-  await i.editReply({
-    embeds,
-    files,
-    components: components,
-  })
+  await i
+    .editReply({
+      embeds,
+      files,
+      components: components,
+    })
+    .catch(() => null)
 }
 
 async function composeTokenWatchlist(msg: Message) {

--- a/src/commands/defi/watchlist_slash/view.ts
+++ b/src/commands/defi/watchlist_slash/view.ts
@@ -372,7 +372,7 @@ function collectButton(msg: Message) {
       await switchView(i)
     })
     .on("end", () => {
-      msg.edit({ components: [] })
+      msg.edit({ components: [] }).catch(() => null)
     })
 }
 
@@ -390,11 +390,13 @@ async function switchView(i: ButtonInteraction) {
       ;({ embeds, files, components } = await composeTokenWatchlist())
       break
   }
-  await i.editReply({
-    embeds,
-    files,
-    components: components,
-  })
+  await i
+    .editReply({
+      embeds,
+      files,
+      components: components,
+    })
+    .catch(() => null)
 }
 
 async function composeTokenWatchlist() {


### PR DESCRIPTION
**What does this PR do?**

-   [x] Temporary fix for `$wl view` when the message is deleted before the edit operation finishes.

**How to test**
`$wl view`
click NFT button to switch to nft view
quickly delete the message
the collector handler will run but now `msg` had been removed so Uknown Message exception is thrown