### PR TITLE
fix: cannot send msg

### DIFF
--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -208,6 +208,8 @@ async function sendDMToUser(guildName: string, inviteeID: string) {
   const embedTickerEth = await defaultTickerEth()
 
   client.users.fetch(inviteeID).then(async (user) => {
+    if (user.bot) return
+
     const embedVote = await handle(user)
     user
       .createDM()


### PR DESCRIPTION
**What does this PR do?**

-   [x] fix: cannot send msg

**Description**

- When server add new bot, mochi will trigger event `guildMemberAdd` and send DM to bot, but discord does not allow a bot send DM to another bot