### PR TITLE
fix: add floor price nft query

### DIFF
--- a/src/commands/community/nft/query.ts
+++ b/src/commands/community/nft/query.ts
@@ -509,10 +509,15 @@ export async function composeNFTDetail(
   const restListing = marketplace.slice(1)
   const firstHalf = restListing.slice(0, Math.ceil(restListing.length / 2))
   const secondHalf = restListing.slice(Math.ceil(restListing.length / 2))
+
   const renderMarket = (m: any) => {
-    return `[${getEmoji(m.platform_name)}](${m.item_url}) ${getEmoji(
+    return `[${getEmoji(m.platform_name)} **${capFirst(m.platform_name)}**](${
+      m.item_url
+    })\n${getEmoji("reply")}${getEmoji(
       m.payment_token
-    )} ${getCompactFormatedNumber(m.listing_price)}`
+    )} ${getCompactFormatedNumber(m.listing_price)} (${getEmoji(
+      "floorprice"
+    )} ${getCompactFormatedNumber(m.floor_price)})`
   }
 
   const listingFields: EmbedFieldData[] = [

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1350,6 +1350,7 @@ export interface ResponseNewGuildGroupNFTRoleResponse {
 
 export interface ResponseNftListingMarketplace {
   contract_address?: string;
+  floor_price?: string;
   item_url?: string;
   listing_price?: string;
   listing_status?: string;

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -176,6 +176,7 @@ export const emojis: { [key: string]: string } = {
   NFT: "🖼",
   TICKER: "📈",
   INFO: "🔎",
+  FLOORPRICE: "1029662833144766464",
   ...tokenEmojis,
   ...numberEmojis,
   ...rarityEmojis,


### PR DESCRIPTION
**What does this PR do?**

-   [x] Add floor price beside listing price nft query

**How to test**

`$nft neko 3400`

**Media (Loom or gif)**

<img width="473" alt="CleanShot 2022-10-12 at 14 56 06@2x" src="https://user-images.githubusercontent.com/14150687/195284036-e92875ab-2a9a-4751-b4a5-a8da468ef62a.png">

