### PR TITLE
fix: get title after get fetchMsg

### DIFF
--- a/src/commands/config/reactionRole/list.ts
+++ b/src/commands/config/reactionRole/list.ts
@@ -41,12 +41,12 @@ const command: Command = {
         )
         for (const prom of promiseArr) {
           const [err, fetchedMsg] = await prom
-          const title =
-            fetchedMsg.content ||
-            fetchedMsg.embeds?.[0]?.title ||
-            fetchedMsg.embeds?.[0]?.description ||
-            "Embed Message"
           if (!err && conf.roles?.length > 0) {
+            const title =
+              fetchedMsg.content ||
+              fetchedMsg.embeds?.[0]?.title ||
+              fetchedMsg.embeds?.[0]?.description ||
+              "Embed Message"
             const f = conf.roles.map((role: any) => ({
               role: `<@&${role.id}>`,
               emoji: role.reaction,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -213,6 +213,7 @@ export interface ModelGuildConfigRepostReaction {
   guild_id?: string;
   id?: string;
   quantity?: number;
+  reaction_type?: string;
   repost_channel_id?: string;
 }
 
@@ -479,6 +480,13 @@ export interface RequestConfigLevelRoleRequest {
   guild_id?: string;
   level?: number;
   role_id?: string;
+}
+
+export interface RequestConfigRepostReactionStartStop {
+  emoji_start?: string;
+  emoji_stop?: string;
+  guild_id?: string;
+  repost_channel_id?: string;
 }
 
 export interface RequestConfigRepostRequest {


### PR DESCRIPTION
**What does this PR do?**

-   [x] Get tilte after fetchMsg

**Media (Loom or gif)**
Bug
<img width="579" alt="Screen Shot 2022-10-14 at 10 39 56" src="https://user-images.githubusercontent.com/49946656/195757099-3ab824e6-9445-44d7-b866-4bd8d17e5a6f.png">
