### PR TITLE
refactor: quests rewards

### DIFF
--- a/src/adapters/defi.ts
+++ b/src/adapters/defi.ts
@@ -174,19 +174,30 @@ class Defi extends Fetcher {
     return await this.jsonFetch(`${API_BASE_URL}/defi/coins?query=${query}`)
   }
 
-  async getHistoricalMarketData(
-    coin_id: string,
-    currency: string,
-    days: number
-  ) {
+  async getHistoricalMarketData({
+    coinId,
+    currency,
+    days = 7,
+    discordId,
+  }: {
+    coinId: string
+    currency: string
+    days?: number
+    discordId?: string
+  }) {
     return await this.jsonFetch<{
       times: string[]
       prices: number[]
       from: string
       to: string
-    }>(
-      `${API_BASE_URL}/defi/market-chart?coin_id=${coin_id}&currency=${currency}&days=${days}`
-    )
+    }>(`${API_BASE_URL}/defi/market-chart`, {
+      query: {
+        coin_id: coinId,
+        currency,
+        days,
+        ...(discordId && { discordId }),
+      },
+    })
   }
 
   async compareToken(

--- a/src/commands/community/quest/daily.ts
+++ b/src/commands/community/quest/daily.ts
@@ -92,8 +92,12 @@ export async function handleClaimReward(i: ButtonInteraction) {
 
   embed.fields = Object.values(data).map((d: any) => {
     return {
-      name: `\`${d.total}\` ${d.reward_type}`,
-      value: d.list.map((e: any) => `${getEmoji("blank")} ${e}`).join("\n"),
+      name: `${getEmoji(d.reward_type, d.reward_type === "xp")} \`${
+        d.total
+      }\` ${d.reward_type}`,
+      value: d.list
+        .map((e: any) => `${getEmoji("blank")}${getEmoji("reply")} ${e}`)
+        .join("\n"),
       inline: false,
     }
   })
@@ -143,15 +147,23 @@ export async function run(userId: string, msg: Message | null) {
   embed.fields = res.data
     .filter((d: any) => d.action !== "bonus")
     .map((d: any) => {
+      const rewards = d.quest.rewards
+        .map(
+          (r: any) =>
+            `${getEmoji(r.reward_type.name, r.reward_type.name === "xp")} \`${
+              r.reward_amount
+            }\` ${r.reward_type.name}`
+        )
+        .join(" and ")
       return {
         name: `**${d.quest.title}**`,
         value: `${getEmoji(
           d.is_completed ? "approve" : "approve_grey"
         )} ${buildProgressBar({
           emoji,
-          total: d.quest.frequency,
-          progress: d.quest.current,
-        })} \`${d.current}/${d.quest.frequency}\`\n**Rewards:**`,
+          total: d.target,
+          progress: d.current,
+        })} \`${d.current}/${d.target}\`\n**Rewards:** ${rewards}`,
         inline: false,
       }
     })

--- a/src/env.ts
+++ b/src/env.ts
@@ -17,11 +17,14 @@ export const INDEXER_API_SERVER_HOST =
   process.env.INDEXER_API_SERVER_HOST || "https://api.indexer.console.so"
 
 // these are category ids (category = a group of channels), not channel ids
+const LOCAL_EXPERIMENTAL_CATEGORY_ID =
+  process.env.LOCAL_EXPERIMENTAL_CATEGORY_ID || ""
 export const EXPERIMENTAL_CATEGORY_CHANNEL_IDS = [
   // pod office
   "886545596222156841",
   // mochi projects
   "904331724970926120",
+  ...(LOCAL_EXPERIMENTAL_CATEGORY_ID ? [LOCAL_EXPERIMENTAL_CATEGORY_ID] : []),
 ]
 
 export const LOG_CHANNEL_ID = process.env.LOG_CHANNEL_ID || "932579148608729118"

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -297,7 +297,8 @@ async function renderHistoricalMarketChart({
   const { ok, data } = await CacheManager.get({
     pool: "ticker",
     key: `ticker-getHistoricalMarketData-ethereum-${currency}-${days}`,
-    call: () => defi.getHistoricalMarketData("ethereum", currency, days || 7),
+    call: () =>
+      defi.getHistoricalMarketData({ coinId: "ethereum", currency, days }),
   })
   if (!ok) return null
   const { times, prices, from, to } = data

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -293,7 +293,7 @@ export function getGradientColor(
 export async function renderChartImage({
   chartLabel,
   labels,
-  data,
+  data = [],
   colorConfig,
   lineOnly,
 }: {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -177,6 +177,7 @@ export const emojis: { [key: string]: string } = {
   INFO: "🔎",
   FLOORPRICE: "1029662833144766464",
   CHEST: "933339868006871070",
+  XP: "933032436814708768",
   ...tokenEmojis,
   ...numberEmojis,
   ...rarityEmojis,


### PR DESCRIPTION
**What does this PR do?**
Update quest commands
- [x] Render rewards for quest
- [x] Add emojis for reward types
- [x] Progress bar
- [x] Fix: `ticker` quest progress does not update
Reason: ticker API (`/api/v1/defi/market-chart`) does not send `discord_id` to server
=> Send `discord_id` when call the API
- [x] Extra: Small update `$watchlist add/remove`'s response message

**Media**
<img width="588" alt="image" src="https://user-images.githubusercontent.com/34529672/196094024-517a3dea-f58f-4ad1-9ac0-cbf7c2589801.png">
<img width="593" alt="image" src="https://user-images.githubusercontent.com/34529672/196094297-c82c2972-0aec-4e72-9373-27171c766000.png">
