### PR TITLE
fix: empty marketplace

### DIFF
--- a/src/commands/community/nft/ticker.ts
+++ b/src/commands/community/nft/ticker.ts
@@ -155,9 +155,10 @@ export async function composeCollectionInfoEmbed(
     more = `${discord} ${twitter} ${website}`
   }
   const ercFormat = `${data.erc_format ?? "-"}`
-  const marketplaces = data.marketplaces
+  const marketplaces = data.marketplaces?.length
     ? data.marketplaces.map((m: string) => getEmoji(m)).join(" ")
     : "-"
+
   const fields = [
     {
       name: "Symbol",


### PR DESCRIPTION
- [x] Bot crash due to empty fields `marketplace` in embed. Api return `[]` for this case
=> Solution: `marketplace = "-"` when data from api is `[] or null`
<img width="1358" alt="image" src="https://user-images.githubusercontent.com/39881166/196115303-dc5c96d6-b349-4aeb-8b95-36aaacd32310.png">
