### PR TITLE
feat: joinleave channel

### DIFF
--- a/src/adapters/config.ts
+++ b/src/adapters/config.ts
@@ -923,6 +923,33 @@ class Config extends Fetcher {
     )
   }
 
+  public async setJoinLeaveChannel(guildId: string, channelId: string) {
+    return await this.jsonFetch(`${API_BASE_URL}/configs/join-leave`, {
+      method: "POST",
+      body: { guildId, channelId },
+    })
+  }
+
+  public async removeJoinLeaveChannel(guildId: string) {
+    return await this.jsonFetch(`${API_BASE_URL}/configs/join-leave`, {
+      method: "DELETE",
+      body: {
+        guildId,
+      },
+    })
+  }
+
+  public async getJoinLeaveChannel(guildId: string) {
+    return await this.jsonFetch<ResponseGetVoteChannelConfigResponse>(
+      `${API_BASE_URL}/configs/join-leave`,
+      {
+        query: {
+          guildId,
+        },
+      }
+    )
+  }
+
   public async getExcludedRole({ guild_id }: { guild_id: string }) {
     return await this.jsonFetch<ResponseGetGuildPruneExcludeResponse>(
       `${API_BASE_URL}/configs/whitelist-prune`,

--- a/src/commands/config/joinleave/index.ts
+++ b/src/commands/config/joinleave/index.ts
@@ -1,0 +1,42 @@
+import { Command } from "types/common"
+import { composeEmbedMessage } from "utils/discordEmbed"
+import set from "./set"
+import info from "./info"
+import remove from "./remove"
+import { PREFIX, LOG_CHANNEL_GITBOOK } from "utils/constants"
+
+const actions: Record<string, Command> = {
+  set,
+  info,
+  remove,
+}
+
+const command: Command = {
+  id: "join-leave",
+  command: "join-leave",
+  brief: "Notify guild members joining and leaving",
+  category: "Config",
+  onlyAdministrator: true,
+  run: async () => null,
+  getHelpMessage: async (msg) => ({
+    embeds: [
+      composeEmbedMessage(msg, {
+        includeCommandsList: true,
+        usage: `${PREFIX}join-leave <action>`,
+        description:
+          "Configure a channel to monitor guild members joining and leaving",
+        footer: [
+          `Type ${PREFIX}help join-leave <action> for a specific action!`,
+        ],
+        document: LOG_CHANNEL_GITBOOK,
+        title: "Join-leave channel",
+        examples: `${PREFIX}join-leave info`,
+      }),
+    ],
+  }),
+  colorType: "Server",
+  aliases: ["jl"],
+  actions,
+}
+
+export default command

--- a/src/commands/config/joinleave/info.ts
+++ b/src/commands/config/joinleave/info.ts
@@ -1,0 +1,66 @@
+import config from "adapters/config"
+import { Message, User } from "discord.js"
+import { APIError, GuildIdNotFoundError } from "errors"
+import { Command } from "types/common"
+import { PREFIX } from "utils/constants"
+import { composeEmbedMessage } from "utils/discordEmbed"
+
+export async function handle(guildId: string, user: User) {
+  const res = await config.getJoinLeaveChannel(guildId)
+  if (!res.ok) {
+    throw new APIError({ curl: res.curl, description: res.log, user })
+  }
+
+  return res.data
+}
+
+const command: Command = {
+  id: "join-leave_info",
+  command: "info",
+  brief: "Show this server's configured join-leave channel",
+  category: "Community",
+  run: async (msg: Message) => {
+    if (!msg.guildId) {
+      throw new GuildIdNotFoundError({ message: msg })
+    }
+
+    const info = await handle(msg.guildId, msg.author)
+
+    if (!info) {
+      return {
+        messageOptions: {
+          embeds: [
+            composeEmbedMessage(msg, {
+              title: "Join-Leave channel",
+              description: `No join-leave channel configured for this guild.\nSet one with \`${PREFIX}join-leave set <channel>.\``,
+            }),
+          ],
+        },
+      }
+    }
+
+    return {
+      messageOptions: {
+        embeds: [
+          composeEmbedMessage(msg, {
+            title: "Join-Leave channel",
+            description: `<#${info.channel_id}> is currently set.\nTo change channel, run \`${PREFIX}join-leave set <channel>.\``,
+          }),
+        ],
+      },
+    }
+  },
+  getHelpMessage: async (msg) => ({
+    embeds: [
+      composeEmbedMessage(msg, {
+        usage: `${PREFIX}join-leave set <channel>`,
+        examples: `${PREFIX}join-leave set #vote`,
+        includeCommandsList: true,
+      }),
+    ],
+  }),
+  colorType: "Server",
+  onlyAdministrator: true,
+}
+
+export default command

--- a/src/commands/config/joinleave/remove.ts
+++ b/src/commands/config/joinleave/remove.ts
@@ -1,0 +1,53 @@
+import config from "adapters/config"
+import { Message, User } from "discord.js"
+import { APIError, GuildIdNotFoundError } from "errors"
+import { Command } from "types/common"
+import { PREFIX } from "utils/constants"
+import { composeEmbedMessage, getSuccessEmbed } from "utils/discordEmbed"
+
+async function handle(guildId: string, user: User) {
+  const res = await config.removeJoinLeaveChannel(guildId)
+
+  if (!res.ok) {
+    throw new APIError({ curl: res.curl, description: res.log, user })
+  }
+}
+
+const command: Command = {
+  id: "join-leave_remove",
+  command: "remove",
+  brief: "Remove the configured join-leave channel",
+  category: "Community",
+  run: async (msg: Message) => {
+    if (!msg.guildId) {
+      throw new GuildIdNotFoundError({ message: msg })
+    }
+
+    await handle(msg.guildId, msg.author)
+
+    return {
+      messageOptions: {
+        embeds: [
+          getSuccessEmbed({
+            msg,
+            title: "Successfully removed!",
+            description: `No join-leave channel configured for this guild.\nSet one with \`${PREFIX}join-leave set <channel>.\``,
+          }),
+        ],
+      },
+    }
+  },
+  getHelpMessage: async (msg) => ({
+    embeds: [
+      composeEmbedMessage(msg, {
+        usage: `${PREFIX}join-leave remove`,
+        examples: `${PREFIX}join-leave remove`,
+        includeCommandsList: true,
+      }),
+    ],
+  }),
+  colorType: "Server",
+  onlyAdministrator: true,
+}
+
+export default command

--- a/src/commands/config/joinleave/set.ts
+++ b/src/commands/config/joinleave/set.ts
@@ -1,0 +1,65 @@
+import config from "adapters/config"
+import { Message, User } from "discord.js"
+import { APIError, CommandError, GuildIdNotFoundError } from "errors"
+import { Command } from "types/common"
+import { getCommandArguments, parseDiscordToken } from "utils/commands"
+import { PREFIX } from "utils/constants"
+import { composeEmbedMessage, getSuccessEmbed } from "utils/discordEmbed"
+import { handle as handleInfo } from "./info"
+
+async function handle(channelId: string, guildId: string, user: User) {
+  const res = await config.setJoinLeaveChannel(guildId, channelId)
+
+  if (!res.ok) {
+    throw new APIError({ curl: res.curl, description: res.log, user })
+  }
+}
+
+const command: Command = {
+  id: "join-leave_set",
+  command: "set",
+  brief: "Set a specific channel to log members joining and leaving",
+  category: "Config",
+  run: async (msg: Message) => {
+    if (!msg.guildId) {
+      throw new GuildIdNotFoundError({ message: msg })
+    }
+
+    const args = getCommandArguments(msg)
+    const { isChannel, id: channelId } = parseDiscordToken(args[2])
+    if (!isChannel) {
+      throw new CommandError({
+        message: msg,
+        description: "The argument is not a channel",
+      })
+    }
+
+    await handle(channelId, msg.guildId, msg.author)
+    const info = await handleInfo(msg.guildId, msg.author)
+
+    return {
+      messageOptions: {
+        embeds: [
+          getSuccessEmbed({
+            msg,
+            title: "Successfully set!",
+            description: `<#${info.channel_id}> is currently set.\nTo change channel, run \`${PREFIX}join-leave set <channel>.\``,
+          }),
+        ],
+      },
+    }
+  },
+  getHelpMessage: async (msg) => ({
+    embeds: [
+      composeEmbedMessage(msg, {
+        usage: `${PREFIX}join-leave set <channel>`,
+        examples: `${PREFIX}join-leave set #general`,
+        includeCommandsList: true,
+      }),
+    ],
+  }),
+  colorType: "Server",
+  onlyAdministrator: true,
+}
+
+export default command

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -16,6 +16,7 @@ import gm from "./community/gm"
 import defaultrole from "./config/defaultRole"
 import reactionrole from "./config/reactionRole"
 import starboard from "./config/starboard"
+import joinleave from "./config/joinleave"
 import top from "./community/top"
 import prune from "./community/prune"
 import tripod from "./games/tripod"
@@ -127,6 +128,7 @@ export const originalCommands: Record<string, Command> = {
   // config section
   reactionrole,
   defaultrole,
+  joinleave,
   // whitelist,
   levelrole,
   nftrole,

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -145,11 +145,10 @@ async function setUserDefaultRoles(member: Discord.GuildMember) {
 
 async function welcomeNewMember(member: Discord.GuildMember) {
   const welcomeChannel = await config.getCurrentWelcomeConfig(member.guild.id)
-  if (!welcomeChannel.ok) return
+  if (!welcomeChannel.ok || !welcomeChannel.data) return
 
   const configData = welcomeChannel.data
   if (
-    !configData ||
     !configData.channel_id ||
     !configData.guild_id ||
     !configData.welcome_message

--- a/src/events/guildMemberRemove.ts
+++ b/src/events/guildMemberRemove.ts
@@ -1,0 +1,21 @@
+import { DiscordEvent } from "."
+import webhook from "adapters/webhook"
+import { wrapError } from "utils/wrapError"
+
+const event: DiscordEvent<"guildMemberRemove"> = {
+  name: "guildMemberRemove",
+  once: false,
+  execute: async (member) => {
+    wrapError(null, async () => {
+      const data = {
+        guild_id: member.guild.id,
+        discord_id: member.id,
+        username: member.displayName,
+        avatar: member.displayAvatarURL(),
+      }
+      await webhook.pushDiscordWebhook("guildMemberRemove", data)
+    })
+  },
+}
+
+export default event

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -4,6 +4,7 @@ import ready from "./ready"
 import interactionCreate from "./interactionCreate"
 import messageReactionAdd from "./messageReactionAdd"
 import guildCreate from "./guildCreate"
+import guildMemberRemove from "./guildMemberRemove"
 import guildMemberAdd from "./guildMemberAdd"
 import inviteDelete from "./inviteDelete"
 import inviteCreate from "./inviteCreate"
@@ -29,4 +30,5 @@ export default [
   inviteDelete,
   guildCreate,
   guildDelete,
+  guildMemberRemove,
 ]

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -648,6 +648,7 @@ export interface RequestTwitterPost {
 export interface RequestUpdateGuildRequest {
   active?: boolean;
   global_xp?: boolean;
+  left_at?: string;
   log_channel?: string;
 }
 


### PR DESCRIPTION
**What does this PR do?**

- New command set `$joinleave` or `$jl`  with actions `set, info, remove` to config join-leave monitoring channel
- Add a new intent `GUILD_PRESENCES`
- Send webhook with event `guildMemberRemove` - user kicked or leaving server

![image](https://user-images.githubusercontent.com/84314071/196372774-d532e92f-9077-4236-bb7b-1a91f9726b24.png)
![image](https://user-images.githubusercontent.com/84314071/196372912-5a9f08ab-a50c-469c-a3fa-fe89576a57fd.png)
![image](https://user-images.githubusercontent.com/84314071/196372973-f12ea229-3e66-4009-a953-0858ab981764.png)
![image](https://user-images.githubusercontent.com/84314071/196372864-380c0615-6df0-4b5a-9ecb-6ae9193233ae.png)


