### PR TITLE
feat: deposit offchain

### DIFF
--- a/src/commands/defi/offchain_tip_bot/airdrop.ts
+++ b/src/commands/defi/offchain_tip_bot/airdrop.ts
@@ -1,0 +1,347 @@
+import { Command } from "types/common"
+import {
+  ButtonInteraction,
+  Message,
+  MessageActionRow,
+  MessageButton,
+} from "discord.js"
+import { AIRDROP_GITBOOK, DEFI_DEFAULT_FOOTER, PREFIX } from "utils/constants"
+import { GuildIdNotFoundError, APIError } from "errors"
+import {
+  defaultEmojis,
+  getEmoji,
+  roundFloatNumber,
+  thumbnails,
+  tripodEmojis,
+} from "utils/common"
+import { getCommandArguments, parseDiscordToken } from "utils/commands"
+import Defi from "adapters/defi"
+import NodeCache from "node-cache"
+import dayjs from "dayjs"
+import { OffchainTipBotTransferRequest } from "types/defi"
+import { composeEmbedMessage, getExitButton } from "utils/discordEmbed"
+
+const airdropCache = new NodeCache({
+  stdTTL: 180,
+  checkperiod: 1,
+  useClones: false,
+})
+
+function composeAirdropButtons(
+  authorId: string,
+  amount: number,
+  amountInUSD: number,
+  cryptocurrency: string,
+  duration: number,
+  maxEntries: number
+) {
+  return new MessageActionRow().addComponents(
+    new MessageButton({
+      customId: `confirm_airdrop_off-${authorId}-${amount}-${amountInUSD}-${cryptocurrency}-${duration}-${maxEntries}`,
+      emoji: "✅",
+      style: "PRIMARY",
+      label: "Confirm",
+    }),
+    getExitButton(authorId, "Cancel")
+  )
+}
+
+export async function confirmAirdropOff(
+  interaction: ButtonInteraction,
+  msg: Message
+) {
+  await interaction.deferUpdate()
+
+  const infos = interaction.customId.split("-")
+  const [authorId, amount, amountInUSD, cryptocurrency, duration, maxEntries] =
+    infos.slice(1)
+  if (authorId !== interaction.user.id) {
+    return
+  }
+  const tokenEmoji = getEmoji(cryptocurrency)
+  const endTime = dayjs()
+    .add(+duration, "second")
+    .toDate()
+  const originalAuthor = await msg.guild?.members.fetch(authorId)
+  const airdropEmbed = composeEmbedMessage(msg, {
+    title: `${defaultEmojis.AIRPLANE} An airdrop appears`,
+    description: `<@${authorId}> left an airdrop of ${tokenEmoji} **${amount} ${cryptocurrency}** (\u2248 $${roundFloatNumber(
+      +amountInUSD,
+      4
+    )})${
+      +maxEntries !== 0
+        ? ` for  ${maxEntries} ${+maxEntries > 1 ? "people" : "person"}`
+        : ""
+    }.`,
+    footer: ["Ends"],
+    timestamp: endTime,
+    originalMsgAuthor: originalAuthor?.user,
+  })
+
+  const reply = await msg
+    .edit({
+      embeds: [airdropEmbed],
+      components: [
+        new MessageActionRow().addComponents(
+          new MessageButton({
+            customId: `enter_airdrop_off-${authorId}-${duration}-${maxEntries}`,
+            label: "Enter airdrop",
+            style: "PRIMARY",
+            emoji: "🎉",
+          })
+        ),
+      ],
+    })
+    .catch(() => null)
+  if (!reply) return
+  const cacheKey = `airdrop-${reply.id}`
+  airdropCache.set(cacheKey, [], +duration)
+
+  // check airdrop expired
+  const description = `<@${authorId}>'s airdrop of ${tokenEmoji} **${amount} ${cryptocurrency}** (\u2248 $${roundFloatNumber(
+    +amountInUSD,
+    4
+  )}) `
+  await checkExpiredAirdrop(
+    reply as Message,
+    cacheKey,
+    description,
+    authorId,
+    +amount,
+    cryptocurrency,
+    duration
+  )
+}
+
+async function checkExpiredAirdrop(
+  msg: Message,
+  cacheKey: string,
+  description: string,
+  authorId: string,
+  amount: number,
+  cryptocurrency: string,
+  duration: string
+) {
+  const getParticipantsStr = (list: string[]) =>
+    list
+      .slice(0, list.length - 1)
+      .join(", ")
+      .concat(list.length === 1 ? list[0] : ` and ${list[list.length - 1]}`)
+
+  airdropCache.on("expired", async (key, participants: string[]) => {
+    if (key === cacheKey) {
+      description +=
+        participants.length === 0
+          ? "has not been collected by anyone :person_shrugging:."
+          : `has been collected by ${getParticipantsStr(participants)}!`
+
+      if (participants.length > 0 && msg.guildId) {
+        const req: OffchainTipBotTransferRequest = {
+          sender: authorId,
+          recipients: participants.map((p) => parseDiscordToken(p).value),
+          guildId: msg.guildId,
+          channelId: msg.channelId,
+          amount,
+          token: cryptocurrency,
+          each: false,
+          all: false,
+          transferType: "airdrop",
+          fullCommand: msg.content,
+          duration: +duration,
+        }
+        await Defi.offchainDiscordTransfer(req)
+      }
+
+      const originalAuthor = await msg.guild?.members.fetch(authorId)
+      msg
+        .edit({
+          embeds: [
+            composeEmbedMessage(msg, {
+              title: `${defaultEmojis.AIRPLANE} An airdrop appears`,
+              footer: [`${participants.length} users joined, ended`],
+              description,
+              originalMsgAuthor: originalAuthor?.user,
+            }),
+          ],
+          components: [],
+        })
+        .catch(() => null)
+    }
+  })
+}
+
+export async function enterAirdropOff(
+  interaction: ButtonInteraction,
+  msg: Message
+) {
+  const infos = interaction.customId.split("-")
+  const [authorId, duration, maxEntries] = infos.slice(1)
+  if (authorId === interaction.user.id) {
+    await interaction.reply({
+      ephemeral: true,
+      embeds: [
+        composeEmbedMessage(msg, {
+          title: `${defaultEmojis.ERROR} Could not enter airdrop`,
+          description: "You cannot enter your own airdrops.",
+        }),
+      ],
+      fetchReply: true,
+    })
+    return
+  }
+
+  const participant = `<@${interaction.user.id}>`
+  const cacheKey = `airdrop-${msg.id}`
+  const participants: string[] = airdropCache.get(cacheKey) ?? []
+  if (participants.includes(participant)) {
+    await interaction.reply({
+      ephemeral: true,
+      embeds: [
+        composeEmbedMessage(msg, {
+          title: `${defaultEmojis.ERROR} Could not enter airdrop`,
+          description: "You are already waiting for this airdrop.",
+        }),
+      ],
+    })
+    return
+  } else {
+    participants.push(participant)
+    await interaction.reply({
+      ephemeral: true,
+      embeds: [
+        composeEmbedMessage(msg, {
+          title: `${defaultEmojis.CHECK} Entered airdrop`,
+          description: `You will receive your reward in ${duration}s.`,
+          footer: ["You will only receive this notification once"],
+        }),
+      ],
+    })
+    if (participants.length === +maxEntries)
+      airdropCache.emit("expired", cacheKey, participants)
+  }
+}
+
+const command: Command = {
+  id: "airdropoff",
+  command: "airdropoff",
+  brief: "Token airdrop offchain",
+  category: "Defi",
+  run: async function (msg: Message) {
+    if (!msg.guildId) {
+      throw new GuildIdNotFoundError({ message: msg })
+    }
+    const args = getCommandArguments(msg)
+    const payload = await Defi.getAirdropPayload(msg, args)
+    // check balance
+    const res = await Defi.offchainGetUserBalances({ userId: payload.sender })
+    if (!res.ok) {
+      throw new APIError({ curl: res.curl, description: res.log })
+    }
+
+    const bals = res.data.map((bal: any) => bal.balances)
+
+    const currentBal = bals[payload.token]
+    if (currentBal < payload.amount && !payload.all) {
+      return {
+        messageOptions: {
+          embeds: [
+            Defi.composeInsufficientBalanceEmbed(
+              msg,
+              currentBal,
+              payload.amount,
+              payload.token
+            ),
+          ],
+        },
+      }
+    }
+    if (payload.all) payload.amount = currentBal
+
+    // ---------------
+    const tokenEmoji = getEmoji(payload.token)
+    const { ok, data: coin } = await Defi.getCoin("ethereum" ?? "")
+    if (!ok) {
+      throw new APIError({ curl: res.curl, description: res.log })
+    }
+    const currentPrice = roundFloatNumber(coin.market_data.current_price["usd"])
+    const amountDescription = `${tokenEmoji} **${roundFloatNumber(
+      payload.amount,
+      4
+    )} ${payload.token}** (\u2248 $${roundFloatNumber(
+      currentPrice * payload.amount,
+      4
+    )})`
+
+    const describeRunTime = (duration = 0) => {
+      const hours = Math.floor(duration / 3600)
+      const mins = Math.floor((duration - hours * 3600) / 60)
+      const secs = duration % 60
+      return `${hours === 0 ? "" : `${hours}h`}${
+        hours === 0 && mins === 0 ? "" : `${mins}m`
+      }${secs === 0 ? "" : `${secs}s`}`
+    }
+    const confirmEmbed = composeEmbedMessage(msg, {
+      title: `${defaultEmojis.AIRPLANE} Confirm airdrop`,
+      description: `Are you sure you want to spend ${amountDescription} on this airdrop?`,
+    }).addFields([
+      {
+        name: "Total reward",
+        value: amountDescription,
+        inline: true,
+      },
+      {
+        name: "Run time",
+        value: `${describeRunTime(payload.duration)}`,
+        inline: true,
+      },
+      {
+        name: "Max entries",
+        value: `${
+          payload.opts?.maxEntries === 0 ? "-" : payload.opts?.maxEntries
+        }`,
+        inline: true,
+      },
+    ])
+
+    return {
+      messageOptions: {
+        embeds: [confirmEmbed],
+        components: [
+          composeAirdropButtons(
+            msg.author.id,
+            payload.amount,
+            currentPrice * payload.amount,
+            payload.token,
+            payload.duration ?? 0,
+            payload.opts?.maxEntries ?? 0
+          ),
+        ],
+      },
+    }
+  },
+  featured: {
+    title: `<:_:${tripodEmojis.AIRDROPPER}> Airdrop`,
+    description:
+      "Airdrop tokens for a specified number of users to collect in a given amount of time",
+  },
+  getHelpMessage: async (msg) => ({
+    embeds: [
+      composeEmbedMessage(msg, {
+        thumbnail: thumbnails.TIP,
+        usage: `${PREFIX}airdrop <amount> <token> [in <duration>] [for <max entries>]`,
+        examples: `${PREFIX}airdrop 10 ftm\n${PREFIX}airdrop 10 ftm in 5m\n${PREFIX}airdrop 10 ftm in 5m for 6`,
+        document: AIRDROP_GITBOOK,
+        description:
+          "Airdrop offchain tokens for a specified number of users to collect in a given amount of time",
+        footer: [DEFI_DEFAULT_FOOTER],
+      }),
+    ],
+  }),
+  canRunWithoutAction: true,
+  aliases: ["drop"],
+  colorType: "Defi",
+  experimental: true,
+  minArguments: 3,
+}
+
+export default command

--- a/src/commands/defi/offchain_tip_bot/balance.ts
+++ b/src/commands/defi/offchain_tip_bot/balance.ts
@@ -1,0 +1,103 @@
+import { Command } from "types/common"
+import { EmbedFieldData, Message } from "discord.js"
+import { BALANCE_GITBOOK, PREFIX, DEFI_DEFAULT_FOOTER } from "utils/constants"
+import {
+  emojis,
+  getEmoji,
+  getEmojiURL,
+  roundFloatNumber,
+  thumbnails,
+} from "utils/common"
+import { APIError } from "errors"
+import Defi from "adapters/defi"
+import { composeEmbedMessage, justifyEmbedFields } from "utils/discordEmbed"
+import { UserBalances } from "types/defi"
+
+const command: Command = {
+  id: "balancesoff",
+  command: "balancesoff",
+  brief: "Wallet balances",
+  category: "Defi",
+  run: async function balances(msg: Message) {
+    // case API return 500 or unpected result
+    const userId = msg.author.id
+    const res = await Defi.offchainGetUserBalances({ userId })
+    if (!res.ok) {
+      throw new APIError({ curl: res.curl, description: res.log })
+    }
+
+    // case data = null || []
+    if (!res.data || res.data.length === 0) {
+      const embed = composeEmbedMessage(msg, {
+        title: "Info",
+        description: `<@${msg.author}>, you have no balances.`,
+      })
+      return {
+        messageOptions: {
+          embeds: [embed],
+        },
+      }
+    }
+
+    // case data normal
+    const fields: EmbedFieldData[] = []
+    const blank = getEmoji("blank")
+    res.data.forEach((balance: UserBalances) => {
+      const tokenName = balance["name"]
+      const tokenEmoji = getEmoji(balance["symbol"])
+      const tokenBalance = roundFloatNumber(balance["balances"], 4)
+      const tokenBalanceInUSD = roundFloatNumber(balance["balances_in_usd"], 4)
+
+      const balanceInfo = `${tokenEmoji} ${tokenBalance} ${balance["symbol"]} \`$${tokenBalanceInUSD}\` ${blank}`
+      fields.push({ name: tokenName, value: balanceInfo, inline: true })
+    })
+
+    const totalBalanceInUSD = res.data.reduce(
+      (accumulator: number, balance: UserBalances) => {
+        return accumulator + balance["balances_in_usd"]
+      },
+      0
+    )
+
+    const embed = composeEmbedMessage(msg, {
+      author: ["View your balances", getEmojiURL(emojis.COIN)],
+    }).addFields(fields)
+    justifyEmbedFields(embed, 3)
+    embed.addFields({
+      name: `Estimated total (U.S dollar)`,
+      value: `${getEmoji("money")} \`$${roundFloatNumber(
+        totalBalanceInUSD,
+        4
+      )}\``,
+    })
+
+    return {
+      messageOptions: {
+        embeds: [embed],
+      },
+    }
+  },
+  featured: {
+    title: `${getEmoji("cash")} Balance`,
+    description: "Show your balances",
+  },
+  getHelpMessage: async (msg) => ({
+    embeds: [
+      composeEmbedMessage(msg, {
+        thumbnail: thumbnails.TOKENS,
+        usage: `${PREFIX}balance`,
+        description: "Show your offchain balances",
+        footer: [DEFI_DEFAULT_FOOTER],
+        examples: `${PREFIX}balance\n${PREFIX}bals\n${PREFIX}bal`,
+        document: BALANCE_GITBOOK,
+      }),
+    ],
+  }),
+  canRunWithoutAction: true,
+  aliases: ["balanceoff", "baloff", "balsoff"],
+  allowDM: true,
+  experimental: true,
+  colorType: "Defi",
+}
+
+export default command

--- a/src/commands/defi/offchain_tip_bot/deposit.ts
+++ b/src/commands/defi/offchain_tip_bot/deposit.ts
@@ -1,0 +1,84 @@
+import { Command } from "types/common"
+import { Message } from "discord.js"
+import { DEPOSIT_GITBOOK, PREFIX, DEFI_DEFAULT_FOOTER } from "utils/constants"
+import { DirectMessageNotAllowedError } from "errors"
+import { composeButtonLink, composeEmbedMessage } from "utils/discordEmbed"
+import { APIError } from "errors"
+import { getEmoji, defaultEmojis } from "utils/common"
+import defi from "adapters/defi"
+import { getCommandArguments } from "utils/commands"
+
+async function deposit(msg: Message) {
+  try {
+    const tokenSymbol = getCommandArguments(msg)[1]
+    const res = await defi.offchainTipBotAssignContract({
+      user_id: msg.author.id,
+      token_symbol: tokenSymbol,
+    })
+
+    if (!res.data) {
+      throw new APIError({ curl: res.curl, description: res.log })
+    }
+
+    const dm = await msg.author.send({
+      embeds: [
+        composeEmbedMessage(msg, {
+          title: `${defaultEmojis.ARROW_DOWN} **Deposit ${tokenSymbol}**`,
+          description: `This is the wallet address linked with your discord account.
+          Please deposit to the below address only.\n\nYour deposit address\n${getEmoji(
+            tokenSymbol.toUpperCase()
+          )}\`${res.data.contract.contract_address}\``,
+        }),
+      ],
+    })
+
+    if (msg.channel.type === "DM") return null
+
+    return {
+      messageOptions: {
+        embeds: [
+          composeEmbedMessage(msg, {
+            description: `:information_source: Info\n<@${msg.author.id}>, your deposit address has been sent to you via a DM`,
+          }),
+        ],
+        components: [composeButtonLink("See the DM", dm.url)],
+      },
+    }
+  } catch (e: any) {
+    if (msg.channel.type !== "DM" && e.httpStatus === 403) {
+      throw new DirectMessageNotAllowedError({ message: msg })
+    }
+    throw e
+  }
+}
+
+const command: Command = {
+  id: "depositoff",
+  command: "depositoff",
+  brief: "Deposit",
+  category: "Defi",
+  run: deposit,
+  featured: {
+    title: `${getEmoji("left_arrow")} Deposit`,
+    description: "Deposit tokens into your in-discord wallet",
+  },
+  getHelpMessage: async (msg) => ({
+    embeds: [
+      composeEmbedMessage(msg, {
+        usage: `${PREFIX}deposit <currency>`,
+        description: "Offchain deposit token",
+        examples: `${PREFIX}deposit eth`,
+        footer: [DEFI_DEFAULT_FOOTER],
+        document: DEPOSIT_GITBOOK,
+      }),
+    ],
+  }),
+  canRunWithoutAction: true,
+  aliases: ["depoff"],
+  allowDM: true,
+  experimental: true,
+  colorType: "Defi",
+  minArguments: 2,
+}
+
+export default command

--- a/src/commands/defi/offchain_tip_bot/tip.ts
+++ b/src/commands/defi/offchain_tip_bot/tip.ts
@@ -1,0 +1,100 @@
+import { Message } from "discord.js"
+import { DEFI_DEFAULT_FOOTER, PREFIX, TIP_GITBOOK } from "utils/constants"
+import {
+  emojis,
+  getEmoji,
+  getEmojiURL,
+  roundFloatNumber,
+  thumbnails,
+} from "utils/common"
+import { getCommandArguments } from "utils/commands"
+import { Command } from "types/common"
+import { composeEmbedMessage, getErrorEmbed } from "utils/discordEmbed"
+import { GuildIdNotFoundError, APIError } from "errors"
+import { parseDiscordToken } from "utils/commands"
+import Defi from "adapters/defi"
+
+async function tip(msg: Message, args: string[]) {
+  // validate valid guild
+  if (!msg.guildId) {
+    throw new GuildIdNotFoundError({ message: msg })
+  }
+
+  // validate valid user
+  const isUser = parseDiscordToken(args[1])
+  if (!isUser) {
+    return {
+      embeds: [
+        getErrorEmbed({
+          msg,
+          description:
+            "Invalid username. Be careful to not be mistaken username with role.",
+        }),
+      ],
+    }
+  }
+
+  // preprocess command arguments
+  const payload = await Defi.getTipPayload(msg, args)
+  payload.fullCommand = msg.content
+  const res = await Defi.offchainDiscordTransfer(payload)
+
+  if (!res.ok) {
+    throw new APIError({ curl: res.curl, description: res.log })
+  }
+
+  const recipientIds: string[] = res.data.map((tx: any) => tx.recipient_id)
+  const mentionUser = (discordId: string) => `<@!${discordId}>`
+  const users = recipientIds.map((id) => mentionUser(id)).join(",")
+  const embed = composeEmbedMessage(msg, {
+    thumbnail: thumbnails.TIP,
+    author: ["Tips", getEmojiURL(emojis.COIN)],
+    description: `${mentionUser(
+      payload.sender
+    )} has sent ${users} **${roundFloatNumber(res.data[0].amount, 4)} ${
+      payload.token
+    }** ${payload.each ? "each" : ""}`,
+  })
+
+  return {
+    embeds: [embed],
+  }
+}
+
+const command: Command = {
+  id: "tipoff",
+  command: "tipoff",
+  brief: "Tip Bot",
+  category: "Defi",
+  run: async function (msg: Message) {
+    const args = getCommandArguments(msg)
+    return {
+      messageOptions: {
+        ...(await tip(msg, args)),
+      },
+    }
+  },
+  featured: {
+    title: `${getEmoji("tip")} Tip`,
+    description: "Send coins to a user or a group of users",
+  },
+  getHelpMessage: async (msg) => ({
+    embeds: [
+      composeEmbedMessage(msg, {
+        thumbnail: thumbnails.TIP,
+        usage: `${PREFIX}tip <@user> <amount> <token>\n${PREFIX}tip <@role> <amount> <token>`,
+        description: "Send coins offchain to a user or a group of users",
+        examples: `${PREFIX}tip @John 10 ftm\n${PREFIX}tip @John all ftm\n${PREFIX}tip @John,@Hank 10 ftm\n${PREFIX}tip @RandomRole 10 ftm`,
+        document: TIP_GITBOOK,
+        footer: [DEFI_DEFAULT_FOOTER],
+        title: "Tip Bot",
+      }),
+    ],
+  }),
+  canRunWithoutAction: true,
+  colorType: "Defi",
+  experimental: true,
+  minArguments: 4,
+}
+
+export default command

--- a/src/commands/defi/offchain_tip_bot/withdraw.ts
+++ b/src/commands/defi/offchain_tip_bot/withdraw.ts
@@ -1,0 +1,134 @@
+import { Command } from "types/common"
+import { Message } from "discord.js"
+import { DEFI_DEFAULT_FOOTER, DEPOSIT_GITBOOK, PREFIX } from "utils/constants"
+import { getCommandArguments } from "utils/commands"
+import Defi from "adapters/defi"
+import {
+  composeButtonLink,
+  composeEmbedMessage,
+  getErrorEmbed,
+} from "utils/discordEmbed"
+import { getEmoji, defaultEmojis } from "utils/common"
+import { APIError } from "errors"
+
+async function getDestinationAddress(
+  msg: Message,
+  dm: Message
+): Promise<string> {
+  const filter = (collected: Message) => collected.author.id === msg.author.id
+  const collected = await dm.channel.awaitMessages({
+    max: 1,
+    filter,
+  })
+  const userReply = collected.first()
+  if (userReply && !userReply.content.trim().startsWith("0x")) {
+    await userReply.reply({
+      embeds: [
+        getErrorEmbed({
+          msg,
+          description: "Invalid input!\nPlease re-enter a valid address...",
+        }),
+      ],
+    })
+    return await getDestinationAddress(msg, dm)
+  }
+  return userReply?.content.trim() ?? ""
+}
+
+async function withdraw(msg: Message, args: string[]) {
+  const payload = await Defi.getWithdrawPayload(msg, args)
+
+  const res = await Defi.offchainDiscordWithdraw()
+  if (!res.ok || !res.data) {
+    throw new APIError({ curl: res.curl, description: res.log })
+  }
+
+  const ftmEmoji = getEmoji("ftm")
+  const tokenEmoji = getEmoji(payload.cryptocurrency)
+  const embedMsg = composeEmbedMessage(msg, {
+    author: ["Withdraw"],
+    title: `${tokenEmoji} ${payload.cryptocurrency.toUpperCase()} sent`,
+    description: "Your withdrawal was processed succesfully!",
+  }).addFields(
+    {
+      name: "Destination address",
+      value: `\`${payload.recipients[0]}\``,
+      inline: false,
+    },
+    {
+      name: "Withdrawal amount",
+      value: `**${res.data.withdrawal_amount}** ${tokenEmoji}`,
+      inline: true,
+    },
+    {
+      name: "Transaction fee",
+      value: `**${res.data.transaction_fee}** ${ftmEmoji}`,
+      inline: true,
+    },
+    {
+      name: "Withdrawal Transaction ID",
+      value: `[${res.data.tx_hash}](${res.data.tx_url})`,
+      inline: false,
+    }
+  )
+
+  await msg.author.send({ embeds: [embedMsg] })
+}
+
+const command: Command = {
+  id: "withdrawoff",
+  command: "withdrawoff",
+  brief: `Token withdrawal`,
+  category: "Defi",
+  run: async function (msg: Message) {
+    const args = getCommandArguments(msg)
+    const dm = await msg.author.send({
+      embeds: [
+        composeEmbedMessage(msg, {
+          title: `${
+            defaultEmojis.GREY_QUESTION
+          } Enter your **${args[2].toUpperCase()}** destination address.`,
+          description: ``,
+        }),
+      ],
+    })
+
+    if (msg.guild !== null) {
+      msg.reply({
+        embeds: [
+          composeEmbedMessage(msg, {
+            description: `:information_source: Info\n<@${msg.author.id}>, a withdrawal message has been sent to you via a DM`,
+          }),
+        ],
+        components: [composeButtonLink("See the DM", dm.url)],
+      })
+    }
+    args[3] = await getDestinationAddress(msg, dm)
+    await withdraw(msg, args)
+
+    return null
+  },
+  featured: {
+    title: `${getEmoji("right_arrow")} Withdraw`,
+    description: "Withdraw tokens to your wallet outside of Discord",
+  },
+  getHelpMessage: async (msg) => {
+    const embedMsg = composeEmbedMessage(msg, {
+      description:
+        "Withdraw tokens to your wallet outside of Discord. A network fee will be added on top of your withdrawal (or deducted if remaining balance is insufficient).\nYou will be asked to confirm it.",
+      usage: `${PREFIX}withdraw <amount> <token>`,
+      examples: `${PREFIX}withdraw 5 ftm`,
+      document: DEPOSIT_GITBOOK,
+      footer: [DEFI_DEFAULT_FOOTER],
+    })
+    return { embeds: [embedMsg] }
+  },
+  canRunWithoutAction: true,
+  aliases: ["wdoff"],
+  colorType: "Defi",
+  allowDM: true,
+  experimental: true,
+  minArguments: 3,
+}
+
+export default command

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,13 +5,18 @@ import profile from "./profile/profile"
 import stats from "./community/stats"
 import nft from "./community/nft"
 import sales from "./community/sales"
-import deposit from "./defi/deposit"
+import depositoff from "./defi/offchain_tip_bot/deposit"
+import balancesoff from "./defi/offchain_tip_bot/balance"
+import tipoff from "./defi/offchain_tip_bot/tip"
+import withdrawoff from "./defi/offchain_tip_bot/withdraw"
+import airdropoff from "./defi/offchain_tip_bot/airdrop"
 import tip from "./defi/tip"
 import balances from "./defi/balances"
+import deposit from "./defi/deposit"
 import withdraw from "./defi/withdraw"
+import airdrop from "./defi/airdrop"
 import tokens from "./defi/token"
 import ticker from "./defi/ticker/ticker"
-import airdrop from "./defi/airdrop"
 import gm from "./community/gm"
 import defaultrole from "./config/defaultRole"
 import reactionrole from "./config/reactionRole"
@@ -107,14 +112,20 @@ export const originalCommands: Record<string, Command> = {
   help,
   // profile section
   profile,
+  // defi offchain section
+  depositoff,
+  tipoff,
+  balancesoff,
+  withdrawoff,
+  airdropoff,
   // defi section
   deposit,
   tip,
   balances,
   withdraw,
+  airdrop,
   tokens,
   ticker,
-  airdrop,
   watchlist,
   // community section
   trade,

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,5 +1,9 @@
 import { slashCommands } from "commands"
 import { confirmGlobalXP } from "commands/config/globalxp"
+import {
+  confirmAirdropOff,
+  enterAirdropOff,
+} from "commands/defi/offchain_tip_bot/airdrop"
 import { confirmAirdrop, enterAirdrop } from "commands/defi/airdrop"
 import { triplePodInteraction } from "commands/games/tripod"
 import { sendVerifyURL } from "commands/profile/verify"
@@ -198,6 +202,12 @@ async function handleButtonInteraction(interaction: Interaction) {
       await msg.delete()
       return
     }
+    case i.customId.startsWith("confirm_airdrop_off-"):
+      await confirmAirdropOff(i, msg)
+      return
+    case i.customId.startsWith("enter_airdrop_off-"):
+      await enterAirdropOff(i, msg)
+      return
     case i.customId.startsWith("confirm_airdrop-"):
       await confirmAirdrop(i, msg)
       return

--- a/src/types/defi.ts
+++ b/src/types/defi.ts
@@ -12,6 +12,21 @@ export type DiscordWalletTransferRequest = {
   transferType: string
 }
 
+export type OffchainTipBotTransferRequest = {
+  sender: string // discordId
+  recipients: string[] // can be array of discordIds or addresses
+  guildId: string
+  channelId: string
+  amount: number
+  token: string
+  each?: boolean
+  all?: boolean
+  transferType: string
+  duration: number
+  fullCommand: string
+  opts?: { duration: number; maxEntries: number }
+}
+
 export type Token = {
   id: number
   address: string
@@ -90,4 +105,12 @@ export type GasPriceData = {
   SafeGasPrice: string
   ProposeGasPrice: string
   FastGasPrice: string
+}
+
+export type UserBalances = {
+  id: string
+  name: string
+  symbol: string
+  balances: number
+  balances_in_usd: number
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -105,6 +105,7 @@ export const defaultEmojis: Record<string, string> = {
   CHART_WITH_DOWNWARDS_TREND: ":chart_with_downwards_trend:",
   MAG: ":mag:",
   X: ":x:",
+  GREY_QUESTION: ":grey_question:",
 }
 
 export const factionEmojis: Record<string, string> = {


### PR DESCRIPTION
- [x] Offchain Defi: create new set defi for offchain & binding api offchain (some api is mock)
- [x] Ignore guild token for offchain first, because it gets data from `offchain_tip_bot_tokens` not from coingecko -> handle in backend
- [x] Mostly get logic from old defi so something looks complicated