### PR TITLE
refactor: quest rewards - streak

### DIFF
--- a/src/commands/community/quest/daily.ts
+++ b/src/commands/community/quest/daily.ts
@@ -72,17 +72,17 @@ export async function handleClaimReward(i: ButtonInteraction) {
       "Congrats! Rewards sent to you, here's the summary of what you just received:",
     footer: ["Daily quests reset at 00:00 UTC"],
   })
-  const data = res.data.reduce((acc: any, d: any) => {
-    const { reward } = d
+  const data = res.data.rewards.reduce((acc: any, d: any) => {
+    const { reward, reward_amount } = d
     const found = acc[reward.reward_type.id]
     if (found) {
-      found.total += Number(reward.reward_amount)
-      found.list.push(`\`${reward.reward_amount}\` - ${reward.quest.title}`)
+      found.total += Number(reward_amount)
+      found.list.push(`\`${reward_amount}\` - ${reward.quest.title}`)
     } else {
       acc[reward.reward_type.id] = {
         reward_type: reward.reward_type.name,
-        total: reward.reward_amount,
-        list: [`\`${reward.reward_amount}\` - ${reward.quest.title}`],
+        total: reward_amount,
+        list: [`\`${reward_amount}\` - ${reward.quest.title}`],
       }
     }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -502,6 +502,7 @@ export interface RequestConfigRepostReactionStartStop {
 
 export interface RequestConfigRepostRequest {
   emoji?: string;
+  emoji_stop?: string;
   guild_id?: string;
   quantity?: number;
   repost_channel_id?: string;


### PR DESCRIPTION
**What does this PR do?**
-   [x] Render streak quest rewards when claim rewards

**Media**
1. Without streak bonus
<img width="645" alt="image" src="https://user-images.githubusercontent.com/34529672/196926929-e0356e77-6632-4de8-b556-36cc907dfb22.png">


2. With upvoting streak bonus (`multiplier = 1.2`)
a. Before claim
<img width="585" alt="image" src="https://user-images.githubusercontent.com/34529672/196923864-9d282779-9f06-497e-9db9-0c7d1105b521.png">

b. Claim rewards
<img width="583" alt="image" src="https://user-images.githubusercontent.com/34529672/196923914-b9deb8d8-7810-4766-98ff-6fd449f6dbaf.png">
