### PR TITLE
fix: ticker chart overlapped

### DIFF
--- a/src/commands/defi/ticker/ticker.ts
+++ b/src/commands/defi/ticker/ticker.ts
@@ -104,9 +104,9 @@ async function renderHistoricalMarketChart({
   // bull/bear
   const isAsc = prices[prices.length - 1] >= prices[0]
   const leftObj = await loadImage(`src/assets/${isAsc ? "blul" : "bera"}1.png`)
-  ctx.drawImage(leftObj, container.x.from, container.y.to - 230, 150, 230)
+  ctx.drawImage(leftObj, container.x.from, container.y.to - 230, 130, 230)
   const rightObj = await loadImage(`src/assets/${isAsc ? "blul" : "bera"}2.png`)
-  ctx.drawImage(rightObj, container.x.to - 150, container.y.to - 230, 150, 230)
+  ctx.drawImage(rightObj, container.x.to - 130, container.y.to - 230, 130, 230)
 
   return new MessageAttachment(canvas.toBuffer(), "chart.png")
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -520,7 +520,6 @@ export interface RequestConfigRepostReactionStartStop {
 
 export interface RequestConfigRepostRequest {
   emoji?: string;
-  emoji_stop?: string;
   guild_id?: string;
   quantity?: number;
   repost_channel_id?: string;


### PR DESCRIPTION
**What does this PR do?**
-   [x] $ticker: right bull/bear sometimes overlapping the chart

**Media**
<img width="542" alt="image" src="https://user-images.githubusercontent.com/34529672/196935394-1ff14c10-f988-4696-bc7f-c966dbac48d0.png">
