### PR TITLE
fix: prune

### DIFF
--- a/src/commands/community/prune/inactive.ts
+++ b/src/commands/community/prune/inactive.ts
@@ -2,14 +2,17 @@ import { ButtonInteraction, MessageActionRow, MessageButton } from "discord.js"
 import { MessageComponentTypes } from "discord.js/typings/enums"
 import { Command } from "types/common"
 import { PREFIX, PRUNE_GITBOOK } from "utils/constants"
-import { composeEmbedMessage } from "utils/discordEmbed"
+import { composeEmbedMessage, getExitButton } from "utils/discordEmbed"
 import { CommandError, GuildIdNotFoundError } from "errors"
 import { getCommandArguments } from "utils/commands"
 
+export const CONFIRM_PRUNE_INACTIVE = "confirm_prune_inactive"
+
 export async function pruneInactiveExecute(i: ButtonInteraction) {
   if (
-    i.customId !== "confirm_prune_inactive" ||
-    i.user.id !== "567326528216760320" //hnh
+    i.customId !== CONFIRM_PRUNE_INACTIVE ||
+    (i.user.id !== "567326528216760320" && //hnh
+      i.user.id !== "463379262620041226") //hollow
   ) {
     return
   }
@@ -69,15 +72,11 @@ const command: Command = {
     })
     const actionRow = new MessageActionRow().addComponents(
       new MessageButton({
-        customId: `confirm_prune_inactive`,
+        customId: CONFIRM_PRUNE_INACTIVE,
         style: "PRIMARY",
         label: "Confirm",
       }),
-      new MessageButton({
-        customId: `cancel_prune_inactive`,
-        style: "SECONDARY",
-        label: "Cancel",
-      })
+      getExitButton(msg.author.id)
     )
     const msgReply = await msg.reply({
       embeds: [embed],
@@ -97,8 +96,8 @@ const command: Command = {
         composeEmbedMessage(msg, {
           description: "Users having roles won't be removed.",
           title: "Remove roleless users with specific inactive days",
-          usage: `${PREFIX}prune inactive`,
-          examples: `${PREFIX}prune inactive`,
+          usage: `${PREFIX}prune inactive <days>`,
+          examples: `${PREFIX}prune inactive 10`,
           document: `${PRUNE_GITBOOK}&action=inactive`,
         }),
       ],

--- a/src/commands/community/prune/without.ts
+++ b/src/commands/community/prune/without.ts
@@ -11,8 +11,10 @@ import { CommandError, GuildIdNotFoundError } from "errors"
 import { Command } from "types/common"
 import { getCommandArguments, parseDiscordToken } from "utils/commands"
 import { PREFIX, PRUNE_GITBOOK } from "utils/constants"
-import { composeEmbedMessage } from "utils/discordEmbed"
+import { composeEmbedMessage, getExitButton } from "utils/discordEmbed"
 import { getExcludedRoles } from "./whitelist"
+
+export const CONFIRM_PRUNE_WITHOUT = "confirm_prune_without"
 
 export async function pruneRoleExecute(
   i: ButtonInteraction,
@@ -20,30 +22,37 @@ export async function pruneRoleExecute(
   roleName: string
 ) {
   if (
-    i.customId !== "confirm_prune_inactive" ||
-    i.user.id !== "567326528216760320" //hnh
+    i.customId !== CONFIRM_PRUNE_WITHOUT ||
+    (i.user.id !== "567326528216760320" && //hnh
+      i.user.id !== "463379262620041226") //hollow
   ) {
     return
   }
   if (!i.guild) throw new GuildIdNotFoundError({})
 
-  let count = 0
   const whitelistRole = await getExcludedRoles(i.guild)
   const whitelistIds: string[] = whitelistRole.map((r) => r.id)
   const invite = i.guild.invites.cache.first()
 
-  pruneList.forEach(async (mem) => {
+  const kicked = pruneList.map(async (mem) => {
     if (
       mem.roles.cache.hasAny(...whitelistIds) ||
       mem.permissions.has("ADMINISTRATOR")
     )
       return
-    await mem.send({
-      content: `Sorry to say this but you haven't had a role yet, so we have to remove you from ${i.guild?.name}\nYou are welcome to join again: ${invite?.url}`,
-    })
+
+    await mem
+      .send({
+        content: `Sorry to say this but you haven't had a role yet, so we have to remove you from ${i.guild?.name}\nYou are welcome to join again: ${invite?.url}`,
+      })
+      // handle user disable DM
+      .catch(() => null)
     await mem.kick(`Missing role ${roleName}`)
-    count++
   })
+
+  const count = (await Promise.allSettled(kicked)).filter(
+    (p) => p.status === "fulfilled"
+  ).length
 
   i.reply({
     ephemeral: true,
@@ -111,15 +120,11 @@ const command: Command = {
     })
     const actionRow = new MessageActionRow().addComponents(
       new MessageButton({
-        customId: `confirm_prune_inactive`,
+        customId: CONFIRM_PRUNE_WITHOUT,
         style: "PRIMARY",
         label: "Confirm",
       }),
-      new MessageButton({
-        customId: `cancel_prune_inactive`,
-        style: "SECONDARY",
-        label: "Cancel",
-      })
+      getExitButton(msg.author.id)
     )
     const msgReply = await msg.reply({
       embeds: [embed],

--- a/src/commands/community/prune_slash/inactive.ts
+++ b/src/commands/community/prune_slash/inactive.ts
@@ -1,8 +1,12 @@
-import { composeEmbedMessage, getErrorEmbed } from "utils/discordEmbed"
+import {
+  composeEmbedMessage,
+  getErrorEmbed,
+  getExitButton,
+} from "utils/discordEmbed"
 import { CommandInteraction, MessageActionRow, MessageButton } from "discord.js"
 import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
 import { MessageComponentTypes } from "discord.js/typings/enums"
-import { pruneInactiveExecute } from "../prune/inactive"
+import { CONFIRM_PRUNE_INACTIVE, pruneInactiveExecute } from "../prune/inactive"
 
 export async function pruneInactive(interaction: CommandInteraction) {
   if (!interaction.guild) {
@@ -50,20 +54,15 @@ export async function pruneInactive(interaction: CommandInteraction) {
   })
   const actionRow = new MessageActionRow().addComponents(
     new MessageButton({
-      customId: `confirm_prune_inactive`,
+      customId: CONFIRM_PRUNE_INACTIVE,
       style: "PRIMARY",
       label: "Confirm",
     }),
-    new MessageButton({
-      customId: `cancel_prune_inactive`,
-      style: "SECONDARY",
-      label: "Cancel",
-    })
+    getExitButton(interaction.user.id)
   )
-  await interaction.reply({
+  await interaction.editReply({
     embeds: [embed],
     components: [actionRow],
-    ephemeral: true,
   })
   const collector = interaction.channel?.createMessageComponentCollector({
     componentType: MessageComponentTypes.BUTTON,

--- a/src/commands/community/prune_slash/without.ts
+++ b/src/commands/community/prune_slash/without.ts
@@ -1,8 +1,16 @@
-import { composeEmbedMessage, getErrorEmbed } from "utils/discordEmbed"
+import {
+  composeEmbedMessage,
+  getErrorEmbed,
+  getExitButton,
+} from "utils/discordEmbed"
 import { CommandInteraction, MessageActionRow, MessageButton } from "discord.js"
 import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
 import { MessageComponentTypes } from "discord.js/typings/enums"
-import { getUsersWithoutRole, pruneRoleExecute } from "../prune/without"
+import {
+  CONFIRM_PRUNE_WITHOUT,
+  getUsersWithoutRole,
+  pruneRoleExecute,
+} from "../prune/without"
 import { CommandError } from "errors"
 
 export async function pruneWithoutRole(interaction: CommandInteraction) {
@@ -43,20 +51,15 @@ export async function pruneWithoutRole(interaction: CommandInteraction) {
   })
   const actionRow = new MessageActionRow().addComponents(
     new MessageButton({
-      customId: `confirm_prune_inactive`,
+      customId: CONFIRM_PRUNE_WITHOUT,
       style: "PRIMARY",
       label: "Confirm",
     }),
-    new MessageButton({
-      customId: `cancel_prune_inactive`,
-      style: "SECONDARY",
-      label: "Cancel",
-    })
+    getExitButton(interaction.user.id)
   )
-  await interaction.reply({
+  await interaction.editReply({
     embeds: [embed],
     components: [actionRow],
-    ephemeral: true,
   })
   const collector = interaction.channel?.createMessageComponentCollector({
     componentType: MessageComponentTypes.BUTTON,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -322,12 +322,25 @@ export interface ModelNewListedNFTCollection {
 
 export interface ModelOffchainTipBotAssignContract {
   chain_id?: string;
+  contract?: ModelOffchainTipBotContract;
   contract_id?: string;
   expired_time?: string;
   id?: string;
   status?: number;
   token_id?: string;
   user_id?: string;
+}
+
+export interface ModelOffchainTipBotContract {
+  assign_status?: number;
+  centralize_wallet?: string;
+  chain_id?: string;
+  contract_address?: string;
+  created_at?: string;
+  id?: string;
+  status?: number;
+  sweeped_time?: string;
+  updated_at?: string;
 }
 
 export interface ModelQuest {
@@ -479,6 +492,11 @@ export interface RequestAddWhitelistCampaignUser {
 
 export interface RequestAddWhitelistCampaignUserRequest {
   users?: RequestAddWhitelistCampaignUser[];
+}
+
+export interface RequestBalcklistChannelRepostConfigRequest {
+  channel_id?: string;
+  guild_id?: string;
 }
 
 export interface RequestClaimQuestsRewardsRequest {
@@ -1566,6 +1584,17 @@ export interface ResponseNftWatchlistSuggest {
 
 export interface ResponseNftWatchlistSuggestResponse {
   data?: ResponseNftWatchlistSuggest;
+}
+
+export interface ResponseOffchainTipBotWithdrawResponse {
+  amount?: number;
+  cryptocurrency?: string;
+  from_discord_id?: string;
+  to_address?: string;
+  transaction_fee?: number;
+  tx_hash?: string;
+  tx_url?: string;
+  withdraw_amount?: number;
 }
 
 export interface ResponseResponseDataMessage {


### PR DESCRIPTION
**What does this PR do?**

-   [x] Fix slash command not able to run, use `editReply` instead of `reply` because interaction already deferred
-   [x] Add hollow user id for easy demo
-   [x] Correct `inactive` help message
-   [x] `without` case: handle situation where user disables DM => flow exit before kick command is run
-   [x] Replace cancel button with exit button